### PR TITLE
East OMERO backports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ home/scriptApproval.xml
 home/secret.key
 home/secret.key.not-so-secret
 home/secrets/
+home/tools/
 home/updates/
 home/users/
 home/userContent/
@@ -37,6 +38,7 @@ home/repositoryPlugin/
 
 pgdata/
 
+server/.bash_history
 server/.java/
 server/.jenkins/
 server/.oracle_jre_usage/
@@ -47,6 +49,8 @@ server/tools/
 nginx/conf.d/
 nginx/log/
 nginx/sslcert/
+nginx/server.crt
+nginx/server.key
 
 jenkins/sslcert/
 

--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -9,7 +9,7 @@
         <hudson.model.BooleanParameterDefinition>
           <name>PURGE_DATA</name>
           <description>Drops and creates the DB, cleans the binary repository</description>
-          <defaultValue>true</defaultValue>
+          <defaultValue>false</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>DB_NAME</name>

--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -103,7 +103,8 @@ $OMERO_DIST/bin/omero config set omero.db.name $OMERO_DB_NAME
 $OMERO_DIST/bin/omero config set omero.db.host $OMERO_DB_HOST
 $OMERO_DIST/bin/omero config set omero.db.user $OMERO_DB_USER
 $OMERO_DIST/bin/omero config set omero.data.dir $OMERO_DATA_DIR
-
+$OMERO_DIST/bin/omero config set omero.fs.repo.path &quot;%user%_%userId%/%thread%//%year%-%month%/%day%/%time%&quot;
+$OMERO_DIST/bin/omero config set omero.db.poolsize 25
 ## END LOAD CONFIG
 
 

--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -105,6 +105,8 @@ $OMERO_DIST/bin/omero config set omero.db.user $OMERO_DB_USER
 $OMERO_DIST/bin/omero config set omero.data.dir $OMERO_DATA_DIR
 $OMERO_DIST/bin/omero config set omero.fs.repo.path &quot;%user%_%userId%/%thread%//%year%-%month%/%day%/%time%&quot;
 $OMERO_DIST/bin/omero config set omero.db.poolsize 25
+$OMERO_DIST/bin/omero config set omero.security.trustStore /etc/pki/ca-trust/extracted/java/cacerts
+$OMERO_DIST/bin/omero config set omero.security.trustStorePassword changeit
 ## END LOAD CONFIG
 
 

--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -84,19 +84,23 @@ $OMERO_DIST/bin/omero config set omero.web.wsgi_args -- &apos;--log-level=DEBUG 
 
 $OMERO_DIST/bin/omero config set omero.web.application_server.host 0.0.0.0
 
-# Hardcoded OMERO.iviewer installation
-pip install omero-iviewer
+# OMERO.iviewer installation
+pip install -U omero-iviewer
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_iviewer&quot;&apos;
 $OMERO_DIST/bin/omero config set omero.web.viewer.view omero_iviewer.views.index
 $OMERO_DIST/bin/omero config append omero.web.open_with &apos;[&quot;omero_iviewer&quot;, &quot;omero_iviewer_index&quot;, {&quot;supported_objects&quot;:[&quot;images&quot;, &quot;dataset&quot;, &quot;well&quot;], &quot;script_url&quot;: &quot;omero_iviewer/openwith.js&quot;, &quot;label&quot;: &quot;OMERO.iviewer&quot;}]&apos;
 
-# Hardcoded OMERO.figure installation
-pip install omero-figure
+# OMERO.figure installation
+pip install -U omero-figure
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_figure&quot;&apos;
 $OMERO_DIST/bin/omero config append omero.web.ui.top_links &apos;[&quot;Figure&quot;, &quot;figure_index&quot;, {&quot;title&quot;: &quot;Open Figure in new tab&quot;, &quot;target&quot;: &quot;_blank&quot;}]&apos;
 $OMERO_DIST/bin/omero config append omero.web.open_with &apos;[&quot;omero_figure&quot;, &quot;new_figure&quot;, {&quot;supported_objects&quot;:[&quot;images&quot;], &quot;target&quot;: &quot;_blank&quot;, &quot;label&quot;: &quot;OMERO.figure&quot;}]&apos;
 
-# Hardcoded twitter testing example
+# OMERO.weberror installation
+pip install -U omero-weberror
+$OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_weberror&quot;&apos;
+
+# Twitter testing example
 $OMERO_DIST/bin/omero config set omero.web.sharing.opengraph &apos;{&quot;omero&quot;:&quot;Open Microscopy&quot;}&apos;
 $OMERO_DIST/bin/omero config set omero.web.sharing.twitter &apos;{&quot;omero&quot;:&quot;@openmicroscopy&quot;}&apos;
 $OMERO_DIST/bin/omero config set omero.web.public.enabled true
@@ -107,6 +111,10 @@ $OMERO_DIST/bin/omero config set omero.web.public.url_filter &apos;^/&apos;
 # Security
 $OMERO_DIST/bin/omero config set omero.web.session_cookie_secure true
 $OMERO_DIST/bin/omero config set omero.web.csrf_cookie_secure true
+
+# QA feedback configuration
+$OMERO_DIST/bin/omero config set omero.web.feedback.comment.enabled false
+$OMERO_DIST/bin/omero config set omero.web.feedback.error.enabled false
 
 BUILD_ID=DONT_KILL_ME $OMERO_DIST/bin/omero web start
 $OMERO_DIST/bin/omero web diagnostics

--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -73,8 +73,8 @@ $OMERO_DIST/bin/omero config set omero.web.caches &apos;{&quot;default&quot;: {&
 
 $OMERO_DIST/bin/omero config set omero.web.server_list &apos;[[&quot;omero&quot;, 4064, &quot;omero&quot;], [&quot;testintegration&quot;, 14064, &quot;testintegration&quot;]]&apos;
 
+$OMERO_DIST/bin/omero config set omero.web.application_server.host $NODE_NAME
 $OMERO_DIST/bin/omero config set omero.web.application_server.port 4080
-$OMERO_DIST/bin/omero config set omero.web.application_server.host 0.0.0.0
 
 $OMERO_DIST/bin/omero web config nginx --http &quot;$OMERO_WEB_PORT&quot; &gt;$OMERO_DIST/nginx.conf.tmp
 
@@ -82,6 +82,7 @@ sudo cp $OMERO_DIST/nginx.conf.tmp $HOME/nginx/$NODE_NAME.conf
 
 $OMERO_DIST/bin/omero config set omero.web.wsgi_args -- &apos;--log-level=DEBUG --error-logfile=&apos;$OMERO_DIST&apos;/var/log/gunicorn.err&apos;
 
+$OMERO_DIST/bin/omero config set omero.web.application_server.host 0.0.0.0
 
 # Hardcoded OMERO.iviewer installation
 pip install omero-iviewer


### PR DESCRIPTION
A few backports from the OMERO.server/OMERO.web deployments on `east-ci`

- do not purge the database by default
- set more production server configuration for OMERO imports (poolsize, omero.fs.repo.path for concurrent imports, security)
- revert unwanted change to `omero.web.application_server.host`
- add OMERO.weberror app and disabled Web feedback