### PR TITLE
Disable omero.web.*_secure

### DIFF
--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -103,9 +103,9 @@ $OMERO_DIST/bin/omero config set omero.web.public.user public
 $OMERO_DIST/bin/omero config set omero.web.public.password public
 $OMERO_DIST/bin/omero config set omero.web.public.url_filter &apos;^/&apos;
 
-# Security
-$OMERO_DIST/bin/omero config set omero.web.session_cookie_secure true
-$OMERO_DIST/bin/omero config set omero.web.csrf_cookie_secure true
+# Security: Breaks internal connections to http://nginx/
+# $OMERO_DIST/bin/omero config set omero.web.session_cookie_secure true
+# $OMERO_DIST/bin/omero config set omero.web.csrf_cookie_secure true
 
 BUILD_ID=DONT_KILL_ME $OMERO_DIST/bin/omero web start
 $OMERO_DIST/bin/omero web diagnostics


### PR DESCRIPTION
Some jobs are configured to connect to http://nginx/ (e.g. Training JSON login https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-training/9/)

These fail since the cookies are only valid over https