### PR TITLE
Remove ice-multi-config block

### DIFF
--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -57,10 +57,7 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>eval $(bash /opt/multi-config.sh ice3.5)
-
-export PATH=/opt/texlive/bin/x86_64-linux:$PATH # for dockerfile
-cd src
+      <command>cd src
 export OMERO_BRANCH=SPACEBRANCH
 virtualenv $WORKSPACE/omero-virtualenv --system-site-packages
 source $WORKSPACE/omero-virtualenv/bin/activate


### PR DESCRIPTION
Fixes #84 

These two environments are now legacy (Ice 3.6 only and no more LaTeX build)