### PR TITLE
Install metadata plugin and Web apps

### DIFF
--- a/home/jobs/OMERO-plugins-push/config.xml
+++ b/home/jobs/OMERO-plugins-push/config.xml
@@ -1,0 +1,59 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.31">
+  <actions>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@1.3.6"/>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@1.3.6">
+      <jobProperties/>
+      <triggers/>
+      <parameters>
+        <string>STATUS</string>
+        <string>MERGE_OPTIONS</string>
+      </parameters>
+      <options/>
+    </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+  </actions>
+  <description>Run scc merge and bump versions on omero-plugins</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>STATUS</name>
+          <description>PR check status</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>success-only</string>
+              <string>no-error</string>
+              <string>none</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>MERGE_OPTIONS</name>
+          <description>scc merge options</description>
+          <defaultValue>-vvv --no-ask --reset --comment</defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.64">
+    <script>node(&apos;testintegration&apos;) {
+
+  library identifier: &apos;recursiveMerge@master&apos;, retriever: modernSCM(
+    [$class: &apos;GitSCMSource&apos;,
+     remote: &apos;git://github.com/ome/jenkins-library-recursivemerge.git&apos;])
+
+  recursiveCheckout(
+    repo: &apos;omero-plugins.git&apos;)
+
+  recursiveMerge(
+    baseRepo: &apos;omero-plugins.git&apos;,
+    parentVersions: &apos;OMERO-build-push&apos;,
+    versionFile: &apos;build/version.tsv&apos;)
+}</script>
+    <sandbox>true</sandbox>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>

--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -106,6 +106,7 @@ virtualenv $WORKSPACE/omero-virtualenv --system-site-packages
 source $WORKSPACE/omero-virtualenv/bin/activate
 
 pip install omego
+pip install git+git://github.com/snoopycrimecop/omero-metadata.git@$MERGE_PUSH_BRANCH#egg=omero-metadata
 
 ## LOAD CONFIG
 

--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -103,13 +103,13 @@ $OMERO_DIST/bin/omero config set omero.web.wsgi_args -- &apos;--log-level=DEBUG 
 $OMERO_DIST/bin/omero config set omero.web.application_server.host 0.0.0.0
 
 # OMERO.iviewer installation
-pip install omero-iviewer
+pip install &quot;git+git://github.com/snoopycrimecop/omero-iviewer.git@$MERGE_PUSH_BRANCH#egg=omero-iviewer&amp;subdirectory=plugin&quot;
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_iviewer&quot;&apos;
 $OMERO_DIST/bin/omero config set omero.web.viewer.view omero_iviewer.views.index
 $OMERO_DIST/bin/omero config append omero.web.open_with &apos;[&quot;omero_iviewer&quot;, &quot;omero_iviewer_index&quot;, {&quot;supported_objects&quot;:[&quot;images&quot;, &quot;dataset&quot;, &quot;well&quot;], &quot;script_url&quot;: &quot;omero_iviewer/openwith.js&quot;, &quot;label&quot;: &quot;OMERO.iviewer&quot;}]&apos;
 
 # OMERO.figure installation
-pip install omero-figure
+pip install git+git://github.com/snoopycrimecop/omero-figure.git@$MERGE_PUSH_BRANCH#egg=omero-figure
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_figure&quot;&apos;
 $OMERO_DIST/bin/omero config append omero.web.ui.top_links &apos;[&quot;Figure&quot;, &quot;figure_index&quot;, {&quot;title&quot;: &quot;Open Figure in new tab&quot;, &quot;target&quot;: &quot;_blank&quot;}]&apos;
 $OMERO_DIST/bin/omero config append omero.web.open_with &apos;[&quot;omero_figure&quot;, &quot;new_figure&quot;, {&quot;supported_objects&quot;:[&quot;images&quot;], &quot;target&quot;: &quot;_blank&quot;, &quot;label&quot;: &quot;OMERO.figure&quot;}]&apos;

--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -103,19 +103,32 @@ $OMERO_DIST/bin/omero config set omero.web.wsgi_args -- &apos;--log-level=DEBUG 
 $OMERO_DIST/bin/omero config set omero.web.application_server.host 0.0.0.0
 
 # OMERO.iviewer installation
-pip install -U omero-iviewer
+pip install omero-iviewer
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_iviewer&quot;&apos;
 $OMERO_DIST/bin/omero config set omero.web.viewer.view omero_iviewer.views.index
 $OMERO_DIST/bin/omero config append omero.web.open_with &apos;[&quot;omero_iviewer&quot;, &quot;omero_iviewer_index&quot;, {&quot;supported_objects&quot;:[&quot;images&quot;, &quot;dataset&quot;, &quot;well&quot;], &quot;script_url&quot;: &quot;omero_iviewer/openwith.js&quot;, &quot;label&quot;: &quot;OMERO.iviewer&quot;}]&apos;
 
 # OMERO.figure installation
-pip install -U omero-figure
+pip install omero-figure
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_figure&quot;&apos;
 $OMERO_DIST/bin/omero config append omero.web.ui.top_links &apos;[&quot;Figure&quot;, &quot;figure_index&quot;, {&quot;title&quot;: &quot;Open Figure in new tab&quot;, &quot;target&quot;: &quot;_blank&quot;}]&apos;
 $OMERO_DIST/bin/omero config append omero.web.open_with &apos;[&quot;omero_figure&quot;, &quot;new_figure&quot;, {&quot;supported_objects&quot;:[&quot;images&quot;], &quot;target&quot;: &quot;_blank&quot;, &quot;label&quot;: &quot;OMERO.figure&quot;}]&apos;
 
+# OMERO.gallery installation
+pip install git+git://github.com/snoopycrimecop/omero-gallery.git@$MERGE_PUSH_BRANCH#egg=omero-gallery
+$OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_gallery&quot;&apos;
+$OMERO_DIST/bin/omero config append omero.web.ui.top_links &apos;[&quot;Gallery&quot;, &quot;webgallery_index&quot;, {&quot;title&quot;: &quot;Browse Gallery&quot;}]&apos;
+$OMERO_DIST/bin/omero config set omero.web.gallery.category_queries &apos;{&quot;all&quot;:{&quot;label&quot;:&quot;All Studies&quot;, &quot;index&quot;:0, &quot;query&quot;:&quot;FIRST50:Name&quot;}}&apos;
+
+# OMERO.parade installation
+pip install git+git://github.com/snoopycrimecop/omero-parade.git@$MERGE_PUSH_BRANCH#egg=omero-parade
+$OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_parade&quot;&apos;
+$OMERO_DIST/bin/omero config append omero.web.ui.center_plugins &apos;[&quot;Parade&quot;, &quot;omero_parade/init.js.html&quot;, &quot;omero_parade&quot;]&apos;
+$OMERO_DIST/bin/omero config set omero.web.use_x_forwarded_host true
+$OMERO_DIST/bin/omero config set omero.web.secure_proxy_ssl_header &apos;[&quot;HTTP_X_FORWARDED_PROTO&quot;, &quot;https&quot;]&apos;
+
 # OMERO.weberror installation
-pip install -U omero-weberror
+pip install git+git://github.com/snoopycrimecop/omero-weberror.git@$MERGE_PUSH_BRANCH#egg=omero-weberror
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_weberror&quot;&apos;
 
 # Twitter testing example

--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -114,6 +114,11 @@ $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_figure&quot
 $OMERO_DIST/bin/omero config append omero.web.ui.top_links &apos;[&quot;Figure&quot;, &quot;figure_index&quot;, {&quot;title&quot;: &quot;Open Figure in new tab&quot;, &quot;target&quot;: &quot;_blank&quot;}]&apos;
 $OMERO_DIST/bin/omero config append omero.web.open_with &apos;[&quot;omero_figure&quot;, &quot;new_figure&quot;, {&quot;supported_objects&quot;:[&quot;images&quot;], &quot;target&quot;: &quot;_blank&quot;, &quot;label&quot;: &quot;OMERO.figure&quot;}]&apos;
 
+# OMERO.fpbioimage installation
+pip install git+git://github.com/snoopycrimecop/omero-fpbioimage.git@$MERGE_PUSH_BRANCH#egg=omero-fpbioimage
+$OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_fpbioimage&quot;&apos;
+$OMERO_DIST/bin/omero config append omero.web.open_with &apos;[&quot;omero_fpbioimage&quot;, &quot;fpbioimage_index&quot;, {&quot;script_url&quot;: &quot;fpbioimage/openwith.js&quot;, &quot;supported_objects&quot;: [&quot;image&quot;], &quot;label&quot;: &quot;FPBioimage&quot;}]&apos;
+
 # OMERO.gallery installation
 pip install git+git://github.com/snoopycrimecop/omero-gallery.git@$MERGE_PUSH_BRANCH#egg=omero-gallery
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_gallery&quot;&apos;
@@ -130,6 +135,16 @@ $OMERO_DIST/bin/omero config set omero.web.secure_proxy_ssl_header &apos;[&quot;
 # OMERO.weberror installation
 pip install git+git://github.com/snoopycrimecop/omero-weberror.git@$MERGE_PUSH_BRANCH#egg=omero-weberror
 $OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_weberror&quot;&apos;
+
+# OMERO.omero-webtagging-autotag installation
+pip install omero-webtagging-autotag
+$OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_webtagging_autotag&quot;&apos;
+$OMERO_DIST/bin/omero config append omero.web.ui.center_plugins &apos;[&quot;Auto Tag&quot;, &quot;omero_webtagging_autotag/auto_tag_init.js.html&quot;, &quot;auto_tag_panel&quot;]&apos;
+
+# OMERO.webtagging-tagsearch installation
+pip install omero-webtagging-tagsearch
+$OMERO_DIST/bin/omero config append omero.web.apps &apos;&quot;omero_webtagging_tagsearch&quot;&apos;
+$OMERO_DIST/bin/omero config append omero.web.ui.top_links &apos;[&quot;Tag Search&quot;, &quot;tagsearch&quot;]&apos;
 
 # Twitter testing example
 $OMERO_DIST/bin/omero config set omero.web.sharing.opengraph &apos;{&quot;omero&quot;:&quot;Open Microscopy&quot;}&apos;

--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -77,6 +77,7 @@
 
         stage(&quot;OMERO Deploy&quot;) {
             steps {
+                build job: &apos;OMERO-plugins-push&apos;, parameters: [string(name: &apos;STATUS&apos;, value: &quot;${params.STATUS}&quot;)]
                 build job: &apos;OMERO-server&apos;
                 build job: &apos;OMERO-web&apos;
                 build job: &apos;nginx&apos;


### PR DESCRIPTION
Follow up of #149, this backports changes made to https://merge-ci.openmicroscopy.org/jenkins/ to start making apps available across devspaces

Changes:

- adds an `OMERO-plugins-push` job that recursively merges all plugins/apps and pushes them to an integration branch
- updates `OMERO-server` to install the integration branch of https://github.com/ome/omero-metadata
- updates `OMERO-web` to install the integration branch of parade, gallery, figure, fpbioimage, webtagging, weberror and iviewer

Once reviewed and merged, proposing to tag this repo  as `0.13.0` and update https://latest-ci.openmicroscopy.org/jenkins/ to have apps/plugins without the opened PRs deployed with the server/web.

/cc @pwalczysko @will-moore 