### PR TITLE
Add default retention policy to template jobs

### DIFF
--- a/TEMPLATE-pipeline-job-config.xml
+++ b/TEMPLATE-pipeline-job-config.xml
@@ -11,7 +11,17 @@
   </actions>
   <description>{DESCRIPTION}</description>
   <keepDependencies>false</keepDependencies>
-  {PROPERTIES}
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>-1</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>5</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+{PROPERTIES}
+  </properties>
   <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.64">
     <scm class="hudson.plugins.git.GitSCM" plugin="git@4.0.0-rc">
       <configVersion>2</configVersion>

--- a/createpipelinejobs.py
+++ b/createpipelinejobs.py
@@ -9,13 +9,11 @@ TEMPLATE_CONFIG_XML = 'TEMPLATE-pipeline-job-config.xml'
 JENKINS_JOBS_DIR = './home/jobs'
 
 PROPERTIES = """\
-  <properties>
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers>
         {TRIGGERS}
       </triggers>
     </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
-  </properties>
 """
 TRIGGER = """\
         <jenkins.triggers.ReverseBuildTrigger>
@@ -46,7 +44,7 @@ def main():
                         for j in jobcfg['after']]
             properties = PROPERTIES.format(TRIGGERS='\n'.join(triggers))
         else:
-            properties = '<properties/>'
+            properties = ''
         job_config_xml = template.format(
             DESCRIPTION=jobcfg['description'],
             REPOSITORY=jobcfg['repository'],


### PR DESCRIPTION
The default template pipeline keeps all artifacts by default leading to a large disk space consumed by a few jobs.

This sets a default retention policy of  keeping at most 5 builds with artifacts. This matches the policy used for other jobs like OMERO-build.

On running devspaces, this will need to be applied manually by modifying the templated build jobs