### PR TITLE
Split OMERO Python jobs into a separate pipeline stage

### DIFF
--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -68,10 +68,15 @@
             }
         }
 
-        stage(&apos;OMERO Distribution&apos;) {
+        stage(&quot;OMERO Python&quot;) {
             steps {
                 build job: &apos;OMERO-python-superbuild-push&apos;, parameters: [string(name: &apos;STATUS&apos;, value: &quot;${params.STATUS}&quot;)]
                 build job: &apos;OMERO-python-superbuild-build&apos;
+            }
+        }
+
+        stage(&apos;OMERO Distribution&apos;) {
+            steps {
                 build job: &apos;OMERO-push&apos;, parameters: [string(name: &apos;STATUS&apos;, value: &quot;${params.STATUS}&quot;)]
                 build job: &apos;OMERO-build&apos;
             }


### PR DESCRIPTION
Backported from `py3-ci` (and already applied to `merge-ci`).

As part of the Python 3 work, being able to separate the Python jobs into a dedicated pipeline stage independent of the distribution stage turned out to be useful.