### PR TITLE
Add logic to consume scripts integration branch in OMERO-build

### DIFF
--- a/home/config.xml
+++ b/home/config.xml
@@ -68,9 +68,11 @@
           <default>
             <comparator class="hudson.util.CaseInsensitiveComparator"/>
           </default>
-          <int>1</int>
+          <int>2</int>
           <string>MERGE_PUSH_BRANCH</string>
           <string>SPACENAME_ci</string>
+          <string>SPACE_USER</string>
+          <string>SPACEUSER</string>
         </tree-map>
       </envVars>
     </hudson.slaves.EnvironmentVariablesNodeProperty>

--- a/home/jobs/OMERO-push/config.xml
+++ b/home/jobs/OMERO-push/config.xml
@@ -95,7 +95,10 @@ touch etc/omero.properties
 ne=$(sed -n &quot;/Internal dependencies/=&quot; &quot;etc/omero.properties.bak&quot;)
 line=$(sed -n &quot;1,&quot;$ne&quot;p&quot; &quot;etc/omero.properties.bak&quot;)
 echo &quot;$line&quot; &gt;&gt; etc/omero.properties
-echo &quot;versions.omero-pypi=https://SPACENAME-ci.openmicroscopy.org/jenkins/job/OMERO-python-superbuild-build/lastSuccessfulBuild/artifact/PACKAGE/dist/&quot; &gt;&gt; etc/omero.properties
+echo &quot;versions.omero-pypi=$JENKINS_URL/job/OMERO-python-superbuild-build/lastSuccessfulBuild/artifact/PACKAGE/dist/&quot; &gt;&gt; etc/omero.properties
+echo &quot;versions.omero-github=https://github.com/$SPACE_USER/PACKAGE/archive&quot; &gt;&gt; etc/omero.properties
+echo &quot;versions.scripts-prefix=&quot; &gt;&gt; etc/omero.properties
+echo &quot;versions.scripts=$MERGE_PUSH_BRANCH&quot; &gt;&gt; etc/omero.properties
 
 cat $WORKSPACE/version.properties &gt;&gt; etc/omero.properties
 git commit -a -m &quot;Add version.properties to etc/omero.properties&quot;


### PR DESCRIPTION
Following the decoupling of the repository, point at the integration repository/branch created by the OMERO-python-superbuild-push job

To reduce the cost of backporting features/propogating upstream changes into the devspaces, 304c88f also includes a proposal to migrate the `SPACEUSER` user as a Jenkins variable similarly to `MERGE_PUSH_BRANCH` - see ab8fef5f77a12182dc2b0e175caf6a68742c84bb.

--depends on https://github.com/ome/openmicroscopy/pull/6181