### PR TITLE
Use SPACE_USER variable in various job configurations

### DIFF
--- a/home/hudson.plugins.git.GitSCM.xml
+++ b/home/hudson.plugins.git.GitSCM.xml
@@ -1,6 +1,6 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <hudson.plugins.git.GitSCM_-DescriptorImpl plugin="git@4.0.0-rc">
-  <generation>29</generation>
+  <generation>31</generation>
   <globalConfigName></globalConfigName>
   <globalConfigEmail></globalConfigEmail>
   <createAccountBasedOnEmail>false</createAccountBasedOnEmail>

--- a/home/jobs/BIOFORMATS-build-docs/config.xml
+++ b/home/jobs/BIOFORMATS-build-docs/config.xml
@@ -26,7 +26,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git://github.com/SPACEUSER/bio-formats-build</url>
+        <url>git://github.com/$SPACE_USER/bio-formats-build</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/home/jobs/BIOFORMATS-build/config.xml
+++ b/home/jobs/BIOFORMATS-build/config.xml
@@ -26,7 +26,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git://github.com/SPACEUSER/bio-formats-build</url>
+        <url>git://github.com/$SPACE_USER/bio-formats-build</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/home/jobs/BIOFORMATS-image/config.xml
+++ b/home/jobs/BIOFORMATS-image/config.xml
@@ -8,7 +8,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git://github.com/SPACEUSER/bio-formats-build</url>
+        <url>git://github.com/$SPACE_USER/bio-formats-build</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -32,7 +32,7 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>TAG=SPACEUSER/bioformats:$MERGE_PUSH_BRANCH
+      <command>TAG=$SPACE_USER/bioformats:$MERGE_PUSH_BRANCH
 sudo docker build -t $TAG .
 #sudo docker tag $TAG scc-docker-docker.bintray.io/$TAG
 #sudo docker push scc-docker-docker.bintray.io/$TAG</command>

--- a/home/jobs/BIOFORMATS-test-folder/config.xml
+++ b/home/jobs/BIOFORMATS-test-folder/config.xml
@@ -28,6 +28,7 @@
           <name>DOCKER_ARGS</name>
           <description></description>
           <defaultValue>-Dtestng.memory=15g -Dtestng.threadCount=12</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -49,7 +50,7 @@ fi
 if [ $(date +%u) -le 1 ]; then
     DOCKER_ARGS=&quot;$DOCKER_ARGS -Duser.language=fr -Duser.country=FR&quot;
 fi
-sudo docker run --rm --name ${JOB_NAME}_${BUILD_NUMBER}_${MERGE_PUSH_BRANCH} -v $DATA_PATH:/data -v $CONFIG_PATH:/config SPACEUSER/bioformats:${MERGE_PUSH_BRANCH} $DOCKER_ARGS</command>
+sudo docker run --rm --name ${JOB_NAME}_${BUILD_NUMBER}_${MERGE_PUSH_BRANCH} -v $DATA_PATH:/data -v $CONFIG_PATH:/config $SPACE_USER/bioformats:${MERGE_PUSH_BRANCH} $DOCKER_ARGS</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>

--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -17,7 +17,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git://github.com/SPACEUSER/openmicroscopy.git</url>
+        <url>git://github.com/$SPACE_USER/openmicroscopy.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/home/jobs/OMERO-training/config.xml
+++ b/home/jobs/OMERO-training/config.xml
@@ -1,8 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
+  <properties/>
   <scm class="hudson.scm.NullSCM"/>
   <assignedNode>omero</assignedNode>
   <canRoam>false</canRoam>
@@ -16,7 +17,7 @@
       <command>
 rm -rf $WORKSPACE/*</command>
     </hudson.tasks.Shell>
-    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.38.1">
+    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.42">
       <project>OMERO-build</project>
       <filter>src/target/OMERO.server*zip, src/target/OMERO.py*zip, src/target/openmicroscopy*zip</filter>
       <target></target>
@@ -85,6 +86,6 @@ java -cp .:$OMERO_SERVER_DIST/lib/client/* training/Setup</command>
   </builders>
   <publishers/>
   <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.9"/>
   </buildWrappers>
 </project>


### PR DESCRIPTION
Backport from https://merge-ci.openmicroscopy.org/jenkins/.

As a follow-up of the `SPACE_USER` variable introduced in #157, this starts propagating the usage of the variable for all job configurations except OMERO-server, OMERO-web which are still being reviewed as part of the Python 3 work. The goal of this change is to have no divergence for the job configurations under `home/jobs` between the upstream Git repo and a running devspace.

