### PR TITLE
WIP: Update nexus, add pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - docker --version
   - pip install docker-compose
   - docker-compose -v
-  - export USER_ID=`$UID`
+  - export USER_ID=$UID
   - export JENKINS_PASSWORD=*****
 
 install:

--- a/README.md
+++ b/README.md
@@ -108,9 +108,15 @@ Start and configure:
         auth_basic "Restricted";
         auth_basic_user_file /etc/nginx/conf.d/passwdfile;
 
-*   [Optional] Create the `maven-internal` Nexus repository:
+*   [Optional] Create the Nexus repositories:
 
-        $ docker-compose exec nexus /nexus-data/createRepoMavenInternal.sh
+    Wait for Nexus to start: Look for `Started Sonatype Nexus OSS` in the docker logs.
+
+    Reset the admin password if necessary and create Maven and Pypi repositories:
+
+        $ docker-compose exec nexus /initialise-repos.py
+
+    If the admin password was reset you must restart Nexus and rerun the script.
 
 
 ## Deploy on OpenStack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,10 @@ services:
             - REPO_CONFIG
 
     nexus:
-        image: sonatype/nexus3
+        build:
+            context: ./nexus
+            args:
+                USER_ID: ${USER_ID}
         user: ${USER_ID}
         networks:
             - omero-network

--- a/nexus-data/createRepoMavenInternal.json
+++ b/nexus-data/createRepoMavenInternal.json
@@ -1,5 +1,0 @@
-{
-  "name": "createRepoMavenInternal",
-  "type": "groovy",
-  "content": "import org.sonatype.nexus.blobstore.api.BlobStoreManager; import org.sonatype.nexus.repository.maven.LayoutPolicy; import org.sonatype.nexus.repository.storage.WritePolicy; import org.sonatype.nexus.repository.maven.VersionPolicy; repository.createMavenHosted('maven-internal', BlobStoreManager.DEFAULT_BLOBSTORE_NAME, true, VersionPolicy.MIXED, WritePolicy.ALLOW_ONCE, LayoutPolicy.STRICT)"
-}

--- a/nexus-data/createRepoMavenInternal.sh
+++ b/nexus-data/createRepoMavenInternal.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Based on
-# https://github.com/sonatype-nexus-community/nexus-scripting-examples/tree/master/simple-shell-example
-set -eux
-NEXUS=http://localhost:8081/nexus
-curl -f -u admin:admin123 --header "Content-Type: application/json" "$NEXUS/service/rest/v1/script/" -d @/nexus-data/createRepoMavenInternal.json
-curl -X POST -u admin:admin123 --header "Content-Type: text/plain" "$NEXUS/service/rest/v1/script/createRepoMavenInternal/run"
-

--- a/nexus/Dockerfile
+++ b/nexus/Dockerfile
@@ -1,0 +1,13 @@
+FROM sonatype/nexus3:3.19.1
+
+USER root
+RUN yum install -y -q python3 && \
+    python3 -mvenv /venv && \
+    /venv/bin/pip install https://github.com/thiagofigueiro/nexus3-cli/archive/6896fc860d66fe2bf59ebc739ae8dbb7d45d328d.zip
+    # /venv/bin/pip install nexus3-cli==2.1.0
+ADD initialise-repos.py /
+
+# Devspace runs everything as a custom UID, so need to update internal user if USER_ID set
+ARG USER_ID=200
+RUN usermod -u "${USER_ID}" nexus
+USER nexus

--- a/nexus/initialise-repos.py
+++ b/nexus/initialise-repos.py
@@ -1,0 +1,100 @@
+#!/venv/bin/python3
+
+from subprocess import (
+    CalledProcessError,
+    run,
+)
+import sys
+
+from nexuscli.nexus_client import (
+    NexusClient,
+    NexusConfig,
+)
+# https://nexus3-cli.readthedocs.io/en/latest/nexuscli.api.html
+# from nexuscli.api.repository import Repository
+from nexuscli.api.repository.model import (
+    MavenHostedRepository,
+    PypiHostedRepository,
+)
+from nexuscli.api.cleanup_policy.model import CleanupPolicy
+from nexuscli.exception import NexusClientInvalidCleanupPolicy
+
+
+################################################################################
+# Ensure admin password is admin123, requires a restart of Nexus
+################################################################################
+
+try:
+    nexus = NexusClient(NexusConfig(url='http://localhost:8081/nexus'))
+except Exception:
+    print('Login failed, resetting admin password to admin123',
+        file=sys.stderr, flush=True)
+    try:
+        # https://docs.hakuna.cloud/blog/lost-nexus3-admin-password.html
+        r = run([
+            'java',
+            '-jar',
+            './lib/support/nexus-orient-console.jar',
+            'connect plocal:/nexus-data/db/security admin admin; update user SET '
+            'password="$shiro1$SHA-512$1024$NE+wqQq/TmjZMvfI7ENh/g==$V4yPw8T64UQ6'
+            'GfJfxYq2hLsVrBY8D1v+bktfOxGdt4b/9BthpWPNUy/CBk6V9iA0nHpzYzJFWO8v/tZF'
+            'tES8CA==" UPSERT WHERE id="admin"; exit',
+            ],
+            cwd='/opt/sonatype/nexus',
+            check=True,
+        )
+    except CalledProcessError as e:
+        # Returns 1 regardless of whether command succeeded or failed
+        if e.returncode != 1:
+            raise
+    print('Stopping nexus, you will need to restart it',
+        file=sys.stderr, flush=True)
+    run(['kill', '1'], check=True)
+    sys.exit(1)
+
+
+################################################################################
+# Create repositories
+################################################################################
+
+repos = nexus.repositories.raw_list()
+repo_names = set(r['name'] for r in repos)
+
+try:
+    cp = nexus.cleanup_policies.get_by_name('default-14d')
+    print('default-14d cleanup policy already exists')
+except NexusClientInvalidCleanupPolicy:
+    print('Creating default-14d cleanup policy')
+    cp = CleanupPolicy(
+        client=None,
+        name='default-14d',
+        format='all',
+        mode='delete',
+        criteria={'lastBlobUpdated': 14},
+    )
+    nexus.cleanup_policies.create_or_update(cp)
+
+if 'maven-internal' not in repo_names:
+    print('Creating maven-internal')
+    r = MavenHostedRepository(
+        'maven-internal',
+        nexus_client=nexus,
+        cleanup_policy='default-14d',
+    )
+    nexus.repositories.create(r)
+else:
+    print('maven-internal already exists')
+
+if 'pypi-internal' not in repo_names:
+    print('Creating pypi-internal')
+    r = PypiHostedRepository(
+        name='pypi-internal',
+        # BUG: Should be automatically set by the Class but it's not
+        recipe='pypi',
+        nexus_client=nexus,
+        cleanup_policy='default-14d',
+    )
+    nexus.repositories.create(r)
+else:
+    print('pypi-internal already exists')
+


### PR DESCRIPTION
- Reset the `admin` password on new installations (default in the current upstream Docker image is a random string)
- Use `nexus-cli` to create repositories. This should also allow cleanup-policies to be configured for new repositories (it won't modify the policy on existing ones, nor will it modify an existing policy with the same name).
```
$ docker-compose build nexus
$ docker-compose up nexus
```
When Nexus displays the `Started Sonatype Nexus OSS 3.19.1-01` message
```
docker-compose exec nexus /initialise-repos.py
```
This will update the `admin` password and stop nexus only if necessary, otherwise it'll create repositories only if they don't exist.
If nexus was stopped restart it and rerun the script.

`/initialise-repos.py` won't modify existing objects so it's safe to always run.

----

To push to the repo inside devspace (https://help.sonatype.com/repomanager3/formats/pypi-repositories#PyPIRepositories-ConfiguringPyPIClientTools):
```
# cat << EOF > ~/.pypirc
[distutils]
index-servers =
    pypi

[pypi]
repository: http://nexus:8081/nexus/repository/pypi-internal/
username: admin
password: admin123
EOF
```
```
# git clone https://github.com/ome/omego
# cd omego
# python setup.py sdist bdist_wheel
# twine upload dist/*
Uploading distributions to http://nexus:8081/nexus/repository/pypi-internal/
Uploading omego-0.7.1.dev0-py3-none-any.whl
100%|███████████████████████████████████████| 40.1k/40.1k [00:00<00:00, 135kB/s]
Uploading omego-0.7.1.dev0.tar.gz
100%|███████████████████████████████████████| 36.1k/36.1k [00:00<00:00, 315kB/s]
```

To install from the repo inside devspace:
```
# pip install --trusted-host nexus --extra-index-url http://nexus:8081/nexus/repository/pypi-internal/simple omego==0.7.1.dev0
Looking in indexes: https://pypi.org/simple, http://nexus:8081/nexus/repository/pypi-internal/simple
Collecting omego==0.7.1.dev0
  Downloading http://nexus:8081/nexus/repository/pypi-internal/packages/omego/0.7.1.dev0/omego-0.7.1.dev0-py3-none-any.whl
Collecting yaclifw>=0.1.1
  Downloading https://files.pythonhosted.org/packages/48/58/f6ae8938d8726f9ba91a5245a02413953a62ce09aae01345b0ef189925b1/yaclifw-0.2.0.tar.gz
Requirement already satisfied: future in /usr/local/lib/python3.8/site-packages (from omego==0.7.1.dev0) (0.18.2)
Requirement already satisfied: six in /usr/local/lib/python3.8/site-packages (from yaclifw>=0.1.1->omego==0.7.1.dev0) (1.13.0)
Building wheels for collected packages: yaclifw
  Building wheel for yaclifw (setup.py) ... done
  Created wheel for yaclifw: filename=yaclifw-0.2.0-cp38-none-any.whl size=14608 sha256=2e950141514df47b758bf2e57ff73f4e8b1a46830ab8b0215e8ef846a357e7f5
  Stored in directory: /root/.cache/pip/wheels/b4/61/a3/30d948e563cffa78d54a7c9d1d97e69342d28499e116f2b587
Successfully built yaclifw
Installing collected packages: yaclifw, omego
Successfully installed omego-0.7.1.dev0 yaclifw-0.2.0
```
`--trusted-host nexus` is needed inside devspace because it's using a http connection. You could also pass `--index-url` if you want to disable the default pypi.