### PR TITLE
Fix failing build

### DIFF
--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -45,7 +45,7 @@ WORKDIR /tmp/omero-install/linux
 
 RUN JAVAVER=$JAVAVER ICEVER=$ICEVER PGVER=nopg bash install_centos7_nginx.sh
 
-RUN pip install 'Sphinx<2.0.0'
+RUN pip install sphinx
 
 # Install FindBugs
 ENV FINDBUGS_VERSION 3.0.0

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -45,8 +45,6 @@ WORKDIR /tmp/omero-install/linux
 
 RUN JAVAVER=$JAVAVER ICEVER=$ICEVER PGVER=nopg bash install_centos7_nginx.sh
 
-RUN pip install sphinx
-
 # Install FindBugs
 ENV FINDBUGS_VERSION 3.0.0
 ENV FINDBUGS_HOME /opt/findbugs
@@ -83,7 +81,7 @@ RUN chmod a+x /tmp/run.sh
 RUN yum install -y python36
 RUN python3 -m venv /py3 && /py3/bin/pip install -U pip tox future wheel restructuredtext-lint
 RUN /py3/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
-RUN /py3/bin/pip install scc
+RUN /py3/bin/pip install scc Sphinx
 ENV VIRTUAL_ENV=/py3
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 


### PR DESCRIPTION
The Python-2 based Sphinx installation has been failing. Rather than trying to workaround limitations, this installs Sphinx in the activated Python3 virtual environment. Long term, this should rather be done in individual `Docker` image declaring their dependencies however this should fix Travis for the time being.