### PR TITLE
Add new jobs for building the OME website

### DIFF
--- a/.env
+++ b/.env
@@ -23,6 +23,9 @@ POSTGRES_PORT=
 REPO_CURATED=/tmp/curated
 REPO_CONFIG=/tmp/config
 
+# Variables for the website
+WEBSITE_DIR=/tmp/website
+
 # Variables for controlling external dependencies versions
 POSTGRES_VERSION=10
 NGINX_VERSION=1.15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,12 +161,14 @@ services:
             - /var/run/docker.sock:/var/run/docker.sock
             - ${REPO_CURATED}:${REPO_CURATED}:ro
             - ${REPO_CONFIG}:${REPO_CONFIG}:ro
+            - ${WEBSITE_DIR}:${WEBSITE_DIR}
         environment:
             - SLAVE_NAME=docker
             - SLAVE_PARAMS=-labels docker -disableClientsUniqueId -executors ${DOCKER_EXECUTORS}
             - JENKINS_MASTER=${JENKINS_BASE}${JENKINS_PREFIX}
             - REPO_CURATED
             - REPO_CONFIG
+            - WEBSITE_DIR
 
     nexus:
         image: sonatype/nexus3

--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -45,6 +45,14 @@
 
     stages {
 
+        stage(&quot;Website&quot;){
+            steps {
+                build job: &apos;WEBSITE-push&apos;, parameters: [string(name: &apos;STATUS&apos;, value: &quot;${params.STATUS}&quot;)]
+                build job: &apos;WEBSITE-build&apos;
+
+            }
+        }
+
         stage(&quot;Bio-Formats&quot;){
             steps {
 

--- a/home/jobs/WEBSITE-build/config.xml
+++ b/home/jobs/WEBSITE-build/config.xml
@@ -1,0 +1,61 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>-1</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@4.0.0-rc">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>https://github.com/$SPACE_USER/www.openmicroscopy.org</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>$MERGE_PUSH_BRANCH</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions>
+      <hudson.plugins.git.extensions.impl.PruneStaleBranch/>
+      <hudson.plugins.git.extensions.impl.CleanCheckout/>
+    </extensions>
+  </scm>
+  <assignedNode>docker</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <customWorkspace>$WEBSITE_DIR</customWorkspace>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>sudo docker run --rm -v $WEBSITE_DIR:/srv/jekyll -eJEKYLL_UID=$UID jekyll/builder:pages jekyll build --config _config.yml,_prod.yml,_internal.yml
+sudo docker run --rm -v $WEBSITE_DIR/_site:/site jekyll/builder:pages /usr/gem/bin/htmlproofer /site --disable-external
+tar -zcvf www.openmicroscopy.org.tar.gz -C $WEBSITE_DIR/_site ./</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>www.openmicroscopy.org.tar.gz</artifacts>
+      <allowEmptyArchive>false</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
+  </publishers>
+  <buildWrappers/>
+</project>

--- a/home/jobs/WEBSITE-push/config.xml
+++ b/home/jobs/WEBSITE-push/config.xml
@@ -1,0 +1,57 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.31">
+  <actions>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@1.3.6"/>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@1.3.6">
+      <jobProperties/>
+      <triggers/>
+      <parameters>
+        <string>STATUS</string>
+        <string>MERGE_OPTIONS</string>
+      </parameters>
+      <options/>
+    </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+  </actions>
+  <description>Run scc merge and bump versions on omero-build</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>STATUS</name>
+          <description>PR check status</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>none</string>
+              <string>success-only</string>
+              <string>no-error</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>MERGE_OPTIONS</name>
+          <description>scc merge options</description>
+          <defaultValue>-vvv --no-ask --reset --comment</defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.64">
+    <script>node(&apos;testintegration&apos;) {
+
+  library identifier: &apos;recursiveMerge@master&apos;, retriever: modernSCM(
+    [$class: &apos;GitSCMSource&apos;,
+     remote: &apos;git://github.com/ome/jenkins-library-recursivemerge.git&apos;])
+
+  recursiveCheckout(
+    repo: &apos;www.openmicroscopy.org&apos;)
+
+  recursiveMerge(
+    baseRepo: &apos;www.openmicroscopy.org&apos;)
+}</script>
+    <sandbox>true</sandbox>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>


### PR DESCRIPTION
- Create WEBSITE_DIR environment variable for mounting as rw in Docker service
- Add `WEBSITE-push` job merging PRs against www.openmicroscopy.org
- Add `WEBSITE-build` job building using GitHub pages, running htmlproofer and archiving the artifact

This should be tested via an integration devspace first. Note that proposes a departure from our current strategy using GitHub pages for the daily CI deployment of www.openmicroscopy.org. The primary goal is to simplify the review of the private counterpart of the website e.g. during secvuln process.

Also the deployment of the built artifact is not part of this backport. I suspect it should be possible to set up Nginx to serve it under https://merge-ci.openmicroscopy.org/www.openmicroscopy.org but I haven't been able to dedicate time to this feature.