### PR TITLE
Update node install script in web/Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -53,7 +53,7 @@ RUN yum -y install gcc-c++
 # ant for iviewer, make for nodejs
 RUN yum -y install ant make
 RUN yum -y install openssl-devel bzip2-devel expat-devel
-RUN curl -sL https://rpm.nodesource.com/setup | bash
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
 RUN yum install -y nodejs
 # grunt for figure
 RUN npm install -g grunt

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -53,7 +53,7 @@ RUN yum -y install gcc-c++
 # ant for iviewer, make for nodejs
 RUN yum -y install ant make
 RUN yum -y install openssl-devel bzip2-devel expat-devel
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
+RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash
 RUN yum install -y nodejs
 # grunt for figure
 RUN npm install -g grunt


### PR DESCRIPTION
This fixes a deprecation warning installing node (see below) but still fails with:

```
## Installing the NodeSource Node.js 12.x repo...

## Populating apt-get cache...

+ apt-get update
bash: apt-get: command not found
Error executing command, exiting
The command '/bin/sh -c curl -sL https://deb.nodesource.com/setup_12.x | bash' returned a non-zero code: 1
```


```
                             DEPRECATION WARNING                            

  Node.js 0.10 is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_10.x — Node.js 10 LTS "Dubnium"
   * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium" (recommended)
```
