### PR TITLE
OMERO-test-integration pin pytest-xdist<2

### DIFF
--- a/home/jobs/OMERO-test-integration/config.xml
+++ b/home/jobs/OMERO-test-integration/config.xml
@@ -14,9 +14,8 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>if [ ! -e $WORKSPACE/.venv3 ]; then
-    virtualenv $WORKSPACE/.venv3
-fi
+      <command>rm -rf $WORKSPACE/.venv3
+python -m venv $WORKSPACE/.venv3
 
 source $WORKSPACE/.venv3/bin/activate
 pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
@@ -144,6 +143,8 @@ omero admin diagnostics
 # RUN TESTS
 export OMERO_SESSION_DIR=/tmp/$JOB_NAME/$BUILD_NUMBER
 export ICE_CONFIG=$SRC/dist/etc/ice.config
+#export PYTEST_ADDOPTS=&quot;-n16&quot;
+
 echo Running the integration tests with -Dtestng.useDefaultListeners=true
 
 $SRC/build.py -f components/tools/OmeroJava/build.xml -Dtestng.useDefaultListeners=true -Dtestreports.dir=target/reports/integration integration

--- a/home/jobs/OMERO-test-integration/config.xml
+++ b/home/jobs/OMERO-test-integration/config.xml
@@ -21,7 +21,9 @@ source $WORKSPACE/.venv3/bin/activate
 pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
 pip install -U pip future setuptools
 pip install markdown
-pip install mox3 pytest pytest-django pytest-xdist
+# Avoid installing psutil for now
+# https://github.com/pytest-dev/pytest-xdist/issues/585
+pip install mox3 pytest pytest-django &apos;pytest-xdist&lt;2&apos;
 pip install tables
 pip install jinja2
 pip install PyYAML

--- a/home/jobs/OMERO-training/config.xml
+++ b/home/jobs/OMERO-training/config.xml
@@ -14,9 +14,8 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>if [ ! -e $WORKSPACE/.venv3 ]; then
-    virtualenv $WORKSPACE/.venv3
-fi
+      <command>rm -rf $WORKSPACE/.venv3
+python -m venv $WORKSPACE/.venv3
 
 source $WORKSPACE/.venv3/bin/activate
 pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl

--- a/home/jobs/OMERO-training/config.xml
+++ b/home/jobs/OMERO-training/config.xml
@@ -21,7 +21,9 @@ source $WORKSPACE/.venv3/bin/activate
 pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
 pip install -U pip future setuptools
 pip install markdown
-pip install mox3 pytest pytest-xdist
+# Avoid installing psutil for now
+# https://github.com/pytest-dev/pytest-xdist/issues/585
+pip install mox3 pytest &apos;pytest-xdist&lt;2&apos;
 pip install tables
 pip install jinja2
 


### PR DESCRIPTION
This prevents psutil being installed. See https://github.com/pytest-dev/pytest-xdist/issues/585

Note this also contains other changes that were previously made to the job but weren't added here.