### PR TITLE
ome-model: linkcheck job

### DIFF
--- a/home/jobs/BIOFORMATS-push/config.xml
+++ b/home/jobs/BIOFORMATS-push/config.xml
@@ -9,7 +9,7 @@
         <hudson.model.StringParameterDefinition>
           <name>MERGE_OPTIONS</name>
           <description></description>
-          <defaultValue>--no-ask --reset</defaultValue>
+          <defaultValue>--no-ask --reset --comment</defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>

--- a/home/jobs/OME-MODEL-linkcheck/config.xml
+++ b/home/jobs/OME-MODEL-linkcheck/config.xml
@@ -1,0 +1,23 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>docker</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>TAG=$SPACE_USER/bioformats:$MERGE_PUSH_BRANCH
+sudo docker run --rm -w /bio-formats-build/ome-model/docs/sphinx --entrypoint mvn $TAG  install -Dsphinx.builder=linkcheck</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -53,6 +53,7 @@
                 build job: &apos;BIOFORMATS-push&apos;, parameters: [string(name: &apos;STATUS&apos;, value: &quot;${params.STATUS}&quot;)]
                 build job: &apos;BIOFORMATS-build&apos;
                 build job: &apos;BIOFORMATS-image&apos;
+                build job: &apos;OME-MODEL-linkcheck&apos;, wait: false, propagate: false
                 build job: &apos;BIOFORMATS-linkcheck&apos;, wait: false, propagate: false
                 build job: &apos;BIOFORMATS-test-repo&apos;, wait: false, propagate: false
             }


### PR DESCRIPTION
Similar to #166, this adds a job consuming the Docker image to run the Sphinx linkchecker on the ome-model documentation.

This job has been in-place for the last few weeks and supersedes the original job on ci.openmicroscopy.org