### PR TITLE
scc 0.15.0: job adjustements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ home/jobs/**/lastSuccessful
 home/jobs/**/modules/
 home/jobs/**/nextBuildNumber
 home/jobs/**/scm-polling.log
+home/jobs/DATA_REPO_CONFIG-merge/build.xml
+home/jobs/MANAGEMENT_TOOLS-merge/build.xml
 home/logs/
 home/nodeMonitors.xml
 home/org.jenkinsci.plugins.workflow.flow.FlowExecutionList.xml

--- a/home/jobs/BIOFORMATS-push/config.xml
+++ b/home/jobs/BIOFORMATS-push/config.xml
@@ -70,9 +70,11 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>pip install -U --user scc
+      <command>python3 -mvenv venv
+source $WORKSPACE/venv/bin/activate
+pip install -U scc
 
-PATH=$WORKSPACE/bio-formats-build/scripts:$HOME/.local/bin:$PATH
+PATH=$WORKSPACE/bio-formats-build/scripts:$PATH
 
 MERGE_OPTIONS=&quot;$MERGE_OPTIONS -S $STATUS&quot;
 

--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -61,9 +61,11 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>pip install --user scc
+      <command>python3 -mvenv venv
+source $WORKSPACE/venv/bin/activate
+pip install -U scc
 test -e src &amp;&amp; cd src
-$HOME/.local/bin/scc $MERGE_COMMAND -S $STATUS --push $MERGE_PUSH_BRANCH</command>
+scc $MERGE_COMMAND -S $STATUS --push $MERGE_PUSH_BRANCH</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Ant plugin="ant@1.9">
       <targets>clean html linkcheck</targets>

--- a/home/jobs/OMERO-push/config.xml
+++ b/home/jobs/OMERO-push/config.xml
@@ -85,10 +85,12 @@
       <doNotFingerprintArtifacts>false</doNotFingerprintArtifacts>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.tasks.Shell>
-      <command>pip install -U --user scc
+      <command>python3 -mvenv venv
+source $WORKSPACE/venv/bin/activate
+pip install -U --user scc
 test -e src &amp;&amp; cd src
 user=$(git config github.user)
-$HOME/.local/bin/scc $MERGE_COMMAND -S $STATUS
+scc $MERGE_COMMAND -S $STATUS
 cp etc/omero.properties etc/omero.properties.bak
 rm etc/omero.properties
 touch etc/omero.properties


### PR DESCRIPTION
Following the release of [scc 0.15.0](https://pypi.org/project/scc/0.15.0/) all jobs using the local user environment for installing scc started failed due to outdated setuptools and similar issues - see 
https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-push/651/console. To fix this, these changes is propagating the strategy used in https://github.com/ome/build-infra and other job and creating fresh local virtual environments where the Python requirements are installed 
