### PR TITLE
Do not install scc in user-mode

### DIFF
--- a/home/jobs/OMERO-push/config.xml
+++ b/home/jobs/OMERO-push/config.xml
@@ -87,7 +87,7 @@
     <hudson.tasks.Shell>
       <command>python3 -mvenv venv
 source $WORKSPACE/venv/bin/activate
-pip install -U --user scc
+pip install -U scc
 test -e src &amp;&amp; cd src
 user=$(git config github.user)
 scc $MERGE_COMMAND -S $STATUS


### PR DESCRIPTION
The `--user` flag was installing the latest version of `scc` under `~/.local` and preventing the OMERO-push job to use the latest version and deal with the switch to GitHub actions.

Also reviewed that nothing else uses `pip install --user`