### PR TITLE
Fix Bio-Formats deployment job

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ they are associated with and a short description of the jobs.
 | -----------------------|-----------------| ------------------------------------------|----------------------------|
 | Trigger                |                 | Runs all the following jobs in order      |                            |
 | BIOFORMATS-push        | testintegration | Merges all Bio-Formats PRs                | devspace_testintegration_1 |
-| BIOFORMATS-build       | testintegration | Builds Bio-Formats components    | devspace_testintegration_1 |
-| BIOFORMATS-image       | testintegration | Builds a Docker image of Bio-Formats   | devspace_docker_1 |
+| BIOFORMATS-image       | testintegration | Builds a Docker image of Bio-Formats   | devspace_docker_1 D
+| BIOFORMATS-deploy      | testintegration | Deploys the Bio-Formats components    | devspace_testintegration_1 |
 | OMERO-push             | testintegration | Merges all OMERO PRs                      | devspace_testintegration_1 |
 | OMERO-build            | testintegration | Builds OMERO artifacts (server, clients)  | devspace_testintegration_1 |
 | OMERO-server           | omero           | Deploys an OMERO.server                   | devspace_omero_1           |

--- a/home/jobs/BIOFORMATS-build/config.xml
+++ b/home/jobs/BIOFORMATS-build/config.xml
@@ -73,22 +73,12 @@
     </hudson.matrix.LabelAxis>
   </axes>
   <builders>
-    <hudson.tasks.Maven>
-      <targets>clean install</targets>
-      <mavenName>(Default)</mavenName>
-      <pom>bio-formats-build/pom.xml</pom>
-      <properties>dryRun=true
-skipTests=true
-skipSphinxTests=true
-XskipSphinxTests=${SKIP_DOCS_VALIDATION}
-ome-model.uri=file://${WORKSPACE}/bio-formats-build/ome-model/docs/sphinx/target/sphinx/html</properties>
-      <usePrivateRepository>true</usePrivateRepository>
-      <settings class="jenkins.mvn.DefaultSettingsProvider"/>
-      <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
-      <injectBuildVariables>false</injectBuildVariables>
-    </hudson.tasks.Maven>
     <hudson.tasks.Shell>
-      <command>cd ${WORKSPACE}/bio-formats-build
+      <command>python3 -mvenv venv
+source $WORKSPACE/venv/bin/activate
+
+cd bio-formats-build
+pip install -r ome-model/requirements.txt
 mvn deploy -DskipTests -DaltDeploymentRepository=ome.staging::default::http://admin:admin123@nexus:8081/nexus/repository/maven-internal/</command>
     </hudson.tasks.Shell>
   </builders>

--- a/home/jobs/BIOFORMATS-deploy/config.xml
+++ b/home/jobs/BIOFORMATS-deploy/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<matrix-project plugin="matrix-project@1.14">
+<project>
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -9,24 +9,15 @@
         <daysToKeep>-1</daysToKeep>
         <numToKeep>-1</numToKeep>
         <artifactDaysToKeep>-1</artifactDaysToKeep>
-        <artifactNumToKeep>4</artifactNumToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
       </strategy>
     </jenkins.model.BuildDiscarderProperty>
-    <hudson.model.ParametersDefinitionProperty>
-      <parameterDefinitions>
-        <hudson.model.BooleanParameterDefinition>
-          <name>SKIP_DOCS_VALIDATION</name>
-          <description></description>
-          <defaultValue>true</defaultValue>
-        </hudson.model.BooleanParameterDefinition>
-      </parameterDefinitions>
-    </hudson.model.ParametersDefinitionProperty>
   </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@4.0.0-rc">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git://github.com/$SPACE_USER/bio-formats-build</url>
+        <url>https://github.com/$SPACE_USER/bio-formats-build</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -53,25 +44,11 @@
   </scm>
   <assignedNode>testintegration</assignedNode>
   <canRoam>false</canRoam>
-  <disabled>true</disabled>
+  <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
-  <axes>
-    <hudson.matrix.JDKAxis>
-      <name>jdk</name>
-      <values>
-        <string>JDK8</string>
-      </values>
-    </hudson.matrix.JDKAxis>
-    <hudson.matrix.LabelAxis>
-      <name>label</name>
-      <values>
-        <string>testintegration</string>
-      </values>
-    </hudson.matrix.LabelAxis>
-  </axes>
   <builders>
     <hudson.tasks.Shell>
       <command>python3 -mvenv venv
@@ -82,18 +59,6 @@ pip install -r ome-model/requirements.txt
 mvn deploy -DskipTests -DaltDeploymentRepository=ome.staging::default::http://admin:admin123@nexus:8081/nexus/repository/maven-internal/</command>
     </hudson.tasks.Shell>
   </builders>
-  <publishers>
-    <hudson.tasks.ArtifactArchiver>
-      <artifacts>**/target/*.zip,**/target/*.jar,**/target/*.tar*,target/version.properties,target/version.tsv</artifacts>
-      <allowEmptyArchive>false</allowEmptyArchive>
-      <onlyIfSuccessful>false</onlyIfSuccessful>
-      <fingerprint>false</fingerprint>
-      <defaultExcludes>true</defaultExcludes>
-      <caseSensitive>true</caseSensitive>
-    </hudson.tasks.ArtifactArchiver>
-  </publishers>
+  <publishers/>
   <buildWrappers/>
-  <executionStrategy class="hudson.matrix.DefaultMatrixExecutionStrategyImpl">
-    <runSequentially>false</runSequentially>
-  </executionStrategy>
-</matrix-project>
+</project>

--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -53,8 +53,8 @@
                 // build job: &apos;MANAGEMENT_TOOLS-merge&apos;
                 // build job: &apos;DATA_REPO_CONFIG-merge&apos;
                 build job: &apos;BIOFORMATS-push&apos;, parameters: [string(name: &apos;STATUS&apos;, value: &quot;${params.STATUS}&quot;)]
-                build job: &apos;BIOFORMATS-build&apos;
                 build job: &apos;BIOFORMATS-image&apos;
+                build job: &apos;BIOFORMATS-deploy&apos;
                 build job: &apos;OME-MODEL-linkcheck&apos;, wait: false, propagate: false
                 build job: &apos;BIOFORMATS-linkcheck&apos;, wait: false, propagate: false
                 build job: &apos;BIOFORMATS-test-repo&apos;, wait: false, propagate: false


### PR DESCRIPTION
https://github.com/ome/ome-model/pull/138 exposed some limitations in the set up of the BIOFORMATS-build job, namely the absence of step installing the Python dependencies. 

7b72085  modifies BIOFORMATS-build to install these dependencies in a virtual environment.

After initially modifying , I realized that the scope of this job is now only limited to running the deployment of the Maven-built artifacts to the local shared `.m2` (for coupling with the OMERO jobs) and the Nexus repository. eba99c0 is an optional proposal to rename this job and convert it into a simple job rather than a matrix job. 

There is still a lot of duplication between the set up of this job and https://github.com/ome/bio-formats-build/blob/master/Dockerfile. As a next step, it should be possible to make better use of the Docker image to perform the deployment itself but I could not get something to work in a limited amount of time.