### PR TITLE
Install PostgreSQL 10 package

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -46,9 +46,9 @@ WORKDIR /tmp/omero-install/linux
 RUN JAVAVER=$JAVAVER ICEVER=$ICEVER PGVER=nopg bash install_centos7_nginx.sh
 
 # install postgres tools
-RUN yum -y install http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-3.noarch.rpm \
+RUN yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum clean all
-RUN yum -y install postgresql94 \
+RUN yum -y install postgresql10 \
     && yum clean all
 
 EXPOSE 4064

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -57,9 +57,9 @@ RUN curl -fSLO http://downloads.sourceforge.net/project/findbugs/findbugs/$FINDB
 RUN yum -y install maven ant && yum clean all
 
 # install postgres tools
-RUN yum -y install http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-3.noarch.rpm \
+RUN yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && yum clean all
-RUN yum -y install postgresql94 \
+RUN yum -y install postgresql10 \
     && yum clean all
 
 # gradle


### PR DESCRIPTION
The recent scheduled GitHub actions builds have been failing - see https://github.com/ome/devspace/actions/runs/458408568 and https://github.com/ome/devspace/actions/runs/446236754.

Looking at the logs, the issue is related to the PSQL 9.4 client packages installed in the server and slave Dockerfile which are now EOL and have been removed from the PSQL yum repo.

This PR updates the Dockerfile to:
- use the generic RedHat 7 repository RPM - see https://www.postgresql.org/download/linux/redhat/
- install the PSQL 10 client packages - the version was chosen to be inline with the default postgres image using in `docker-compose` 