### PR TITLE
Add .cache folder to .dockerignore for server, slave and web containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
           ./rename.py travis
           ./sslcert jenkins/sslcert localhost
           ./sslcert nginx/sslcert localhost
+      - name: Display Docker version
+        run: docker version
       - name: Build
         run: docker-compose -f docker-compose.yml build
       - name: Run tests

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -33,7 +33,7 @@ RUN usermod -u $USER_ID omero
 RUN mkdir -p /home/omero/static
 RUN chown -R omero:omero /home/omero/static
 
-VOLUME ['/etc/nginx/conf.d', '/home/omero/static', '/var/log/nginx', '/etc/nginx/ssl']
+VOLUME ["/etc/nginx/conf.d", "/home/omero/static", "/var/log/nginx", "/etc/nginx/ssl"]
 
 USER omero
 CMD ["/tmp/run.sh"]

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -2,3 +2,4 @@ omero-server-data
 workspace
 .jenkins
 .local
+.cache

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -78,7 +78,7 @@ ARG USER_ID=1000
 RUN usermod -u $USER_ID omero
 
 # make sure mounted volumes has correct permissions
-VOLUME ['/home/omero']
+VOLUME ["/home/omero"]
 
 USER omero
 CMD ["/tmp/run.sh"]

--- a/slave/.dockerignore
+++ b/slave/.dockerignore
@@ -1,3 +1,4 @@
 workspace
 .jenkins
 .local
+.cache

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -90,7 +90,7 @@ ARG USER_ID=1000
 RUN usermod -u $USER_ID omero
 
 # make sure mounted volumes has correct permissions
-VOLUME ['/home/omero']
+VOLUME ["/home/omero"]
 
 USER omero
 CMD ["/tmp/run.sh"]

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,3 +1,4 @@
 workspace
 .jenkins
 .local
+.cache

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -81,7 +81,7 @@ RUN usermod -u $USER_ID omero
 RUN mkdir -p /home/omero/nginx
 RUN chown -R omero:omero /home/omero/nginx
 
-VOLUME ['/home/omero', '/home/omero/nginx']
+VOLUME ["/home/omero", "/home/omero/nginx"]
 
 USER omero
 CMD ["/tmp/run.sh"]


### PR DESCRIPTION
While working on `latest-ci` and recreating containers via `docker-compose up -d`, the process creates a temporary copy of the context for each container which filled `/tmp`.

After investigating it turns out the issue comes from the `.cache` directories which contain ~10G of data. Adding these folders to `.dockerignore` was sufficient to prevent the creation of unncessary large temporary archives.