### PR TITLE
Disable EPEL repository when installing nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER OME
 
 RUN yum -y localinstall http://nginx.org/packages/rhel/7/noarch/RPMS/nginx-release-rhel-7-0.el7.ngx.noarch.rpm \
     && yum clean all
-RUN yum -y install nginx \
+RUN yum -y install nginx --disablerepo=epel \
     && yum clean all
 RUN mv /etc/nginx/conf.d/default.conf  /etc/nginx/conf.d/default.conf.disabled
 


### PR DESCRIPTION
EPEL ships nginx-1.20.1-2.el7.x86_64.rpm. which includes significant changes to the default /etc/nginx/ configuration, notably moving the default server config under /etc/nginx/nginx.conf - see https://centos.pkgs.org/7/epel-x86_64/nginx-1.20.1-2.el7.x86_64.rpm.html

The NGINX repo installs nginx-1.20.0-1.el7.ngx.x86_64.rpm which preserves the previous layout - see https://centos.pkgs.org/7/nginx-x86_64/nginx-1.20.1-1.el7.ngx.x86_64.rpm.html