### PR TITLE
OMERO.server: self-signed SSL certificates

### DIFF
--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -125,6 +125,8 @@ mv $WORKSPACE/$DIST $OMERO_DIST
 # INSTALL PYTHON PACKAGES
 source $WORKSPACE/.venv3/bin/activate
 pip install git+git://github.com/$SPACE_USER/omero-metadata.git@$MERGE_PUSH_BRANCH#egg=omero-metadata
+pip install git+git://github.com/$SPACE_USER/omero-cli-render.git@$MERGE_PUSH_BRANCH#egg=omero-cli-render
+pip install omero-certificates
 
 for x in *.tar.gz; do
     pip install -U $x # Install marshal, etc. *after* requirements
@@ -144,6 +146,7 @@ omero config set omero.fs.repo.path &quot;%user%_%userId%/%thread%//%year%-%mont
 omero config set omero.db.poolsize 25
 omero config set omero.security.trustStore /etc/pki/ca-trust/extracted/java/cacerts
 omero config set omero.security.trustStorePassword changeit
+omero certificates
 ## END LOAD CONFIG
 
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -70,6 +70,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN yum install -y http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
 RUN yum install -y mencoder
 
+RUN yum install -y openssl
+
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 


### PR DESCRIPTION
- installs the omero-certificates prerequisites (openssl, omero-certificates)
- runs `omero certificates` before starting the server
- 
Deployed on `merge-ci`