### PR TITLE
OMERO-docs: install latest Sphinx in local virtual environment

### DIFF
--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -63,15 +63,14 @@
     <hudson.tasks.Shell>
       <command>python3 -mvenv venv
 source $WORKSPACE/venv/bin/activate
-pip install -U scc
+pip install -U scc Sphinx
 test -e src &amp;&amp; cd src
 scc $MERGE_COMMAND -S $STATUS --push $MERGE_PUSH_BRANCH</command>
     </hudson.tasks.Shell>
-    <hudson.tasks.Ant plugin="ant@1.9">
-      <targets>clean html linkcheck</targets>
-      <antName>Ant 1.9</antName>
-      <buildFile>omero/build.xml</buildFile>
-    </hudson.tasks.Ant>
+    <hudson.tasks.Shell>
+      <command>source $WORKSPACE/venv/bin/activate
+make clean html linkcheck</command>
+    </hudson.tasks.Shell>
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -81,7 +81,7 @@ RUN chmod a+x /tmp/run.sh
 RUN yum install -y python36
 RUN python3 -m venv /py3 && /py3/bin/pip install -U pip tox future wheel restructuredtext-lint
 RUN /py3/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
-RUN /py3/bin/pip install scc Sphinx
+RUN /py3/bin/pip install scc
 ENV VIRTUAL_ENV=/py3
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 


### PR DESCRIPTION
For the OMERO documentation job, Sphinx is currently installed globally in the Docker slave image. A downside of this approach is the difficulty to upgrade this requirement.

As an illustration of the impact, https://latest-ci.openmicroscopy.org/jenkins/job/OMERO-docs/ (and recent merge jobs) has been lately failing with errors of type

```
10:12:09      [exec] (line  630) broken    https://www.openmicroscopy.org/forums - 403 Client Error: Forbidden for url: https://forum.image.sc/c/data-management
```

related to the absence of a valid `User agent` passed during the linkchecking in the Sphinx version (2.4.4). Recent versions of Sphinx correct this issue by passing a valid agent.

As a general rule, our documentation repositories should build with the latest Sphinx especially with the introduction of readthedocs and other CI doc jobs installing Sphinx. This PR adjusts the OMERO-docs job to match the same strategy. The change has been deployed on merge-ci - see https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-docs/927/ for an example with Sphinx 4.1.2