### PR TITLE
BIOFORMATS-image: rotate between JDK versions

### DIFF
--- a/home/jobs/BIOFORMATS-image/config.xml
+++ b/home/jobs/BIOFORMATS-image/config.xml
@@ -32,8 +32,17 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>TAG=$SPACE_USER/bioformats:$MERGE_PUSH_BRANCH
-sudo docker build -t $TAG .
+      <command>if (( $(date +%u) % 2 == 1 )); then
+    BASE_IMAGE=openjdk:8-slim-bullseye
+else
+    BASE_IMAGE=openjdk:11-slim-bullseye
+fi
+
+sudo docker pull $BASE_IMAGE
+
+
+TAG=$SPACE_USER/bioformats:$MERGE_PUSH_BRANCH
+sudo docker build -t $TAG . --build-arg BUILD_IMAGE=$BASE_IMAGE
 #sudo docker tag $TAG scc-docker-docker.bintray.io/$TAG
 #sudo docker push scc-docker-docker.bintray.io/$TAG</command>
     </hudson.tasks.Shell>


### PR DESCRIPTION
The JDK version used for building the Bio-Formats Docker image in the OME CI infrastructure is defined in https://github.com/ome/bio-formats-build/blob/master/Dockerfile#L1 and curently uses 8 as the minimal supported Java LTS version.

This commit allows to switch daily between LTS Java versions to increase our testing coverage. Currently the builds alternates between the supported 8 and 11 versions with 17 being a mid-term target.
In addition a first steps pulls the latest verison of the base image which should allow to avoid issues such as https://github.com/ome/bio-formats-build/pull/241#issuecomment-1034969632

Currently deployed on https://merge-ci.openmicroscopy.org/jenkins/