### PR TITLE
OMERO-test-integration: install self-signed certificates

### DIFF
--- a/home/jobs/OMERO-test-integration/config.xml
+++ b/home/jobs/OMERO-test-integration/config.xml
@@ -93,6 +93,7 @@ source $WORKSPACE/.venv3/bin/activate
 for x in *.tar.gz; do
     pip install -U $x
 done
+pip install omero-certificates
 
 # Cause CLI plugin tests to be run against the relevant version.
 for x in omero-cli-duplicate; do
@@ -119,6 +120,7 @@ omero config set omero.jvmcfg.max_system_memory.blitz 64000
 omero config set omero.data.dir $OMERO_DATA_DIR
 omero config set omero.ports.prefix 1
 omero config set omero.web.server_list &apos;[[&quot;testintegration&quot;,14064,&quot;testintegration&quot;]]&apos;
+omero certificates
 
 ## END LOAD CONFIG
 

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -76,7 +76,7 @@ ADD ./run.sh /tmp/run.sh
 RUN chown omero:omero /tmp/run.sh
 RUN chmod a+x /tmp/run.sh
 
-RUN yum install -y python36
+RUN yum install -y python36 openssl
 RUN python3 -m venv /py3 && /py3/bin/pip install -U pip tox future wheel restructuredtext-lint
 RUN /py3/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
 RUN ln -s /py3/bin/slice2py /usr/bin/slice2py


### PR DESCRIPTION
This mirrors the configuration made in OMERO-server and configure omero-certificates on the integration OMERO.server

Discovered while trying to run Python integration tests directly from the Docker environments using https://omero.readthedocs.io/en/stable/developers/testing.html#running-tests-directly and receiving the famous `Ice.SecurityException: javax.net.ssl.SSLHandshakeException: The server selected protocol version TLS10 is not accepted by client preferences [TLS12]` error. I suspect the CI job set-up includes some bootstrap configuration which allows to avoid the issue but since setting up certificates everywhere is our recommendation, I expect this is a harmless addition.