### PR TITLE
BIOFORMATS-image: rotate between JDK 8, 11 and 17

### DIFF
--- a/home/jobs/BIOFORMATS-image/config.xml
+++ b/home/jobs/BIOFORMATS-image/config.xml
@@ -32,10 +32,12 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>if (( $(date +%u) % 2 == 1 )); then
+      <command>if (( $(date +%u) % 3 == 1 )); then
     BASE_IMAGE=openjdk:8-slim-bullseye
-else
+elif (( $(date +%u) % 3 == 2 )); then
     BASE_IMAGE=openjdk:11-slim-bullseye
+else
+    BASE_IMAGE=openjdk:17-slim-bullseye
 fi
 
 sudo docker pull $BASE_IMAGE


### PR DESCRIPTION
As discussed on Monday Formats meeting, this is the minimal configuration change that should allow the nightly OME CI builds to start testing Bio-Formats on JDK 17 in addition to JDK 8 and JDK 11.

The rotation is currently set so that JDK 17 builds would happen on Wednesday and Saturday to minimize the impact on the OME standup review as I am still expecting some repository failures.

If the plan above is acceptable, next proposed step would be to manually deploy the changes on https://merge-ci.openmicroscopy.org/jenkins/ and mark https://github.com/ome/bioformats/pull/3815 as ready for review for inclusion in the nightly builds.