### PR TITLE
rename repo to ome

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Running Devspace requires access to SSH and Git configuration files used for fet
 Devspace code depends on the following repositories:
 
 * [OMERO install](https://github.com/ome/omero-install/)
-* [devslave-c7-docker](https://github.com/openmicroscopy/devslave-c7-docker)
+* [devslave-c7-docker](https://github.com/ome/devslave-c7-docker)
 
 # Installation
 
@@ -37,7 +37,7 @@ The following instructions explain how to deploy a devspace on a Docker host.
 
 *   Clone the ``devspace`` Git repository:
 
-        $ git clone https://github.com/openmicroscopy/devspace.git
+        $ git clone https://github.com/ome/devspace.git
         $ cd devspace
 
 *   Generated self-signed SSL certificates for the Jenkins and NGINX
@@ -161,9 +161,9 @@ they are associated with and a short description of the jobs.
 This means that by default the following repositories need to be
 forked to your GitHub account:
 
-* [openmiscrocopy/openmiscrocopy](https://github.com/openmicroscopy/openmicroscopy)
-* [openmiscrocopy/ome-documentation](https://github.com/openmicroscopy/ome-documentation)
-* [openmiscrocopy/bioformats](https://github.com/openmicroscopy/bioformats)
+* [ome/openmiscrocopy](https://github.com/ome/openmicroscopy)
+* [ome/ome-documentation](https://github.com/ome/ome-documentation)
+* [ome/bioformats](https://github.com/ome/bioformats)
 
 If you do not have some of the repositories forked, you will need to remove the jobs from the list
 of jobs to run either from the Trigger job [configuration](home/jobs/Trigger/config.xml)
@@ -201,7 +201,7 @@ See [Troubleshooting](Troubleshooting.md)
 In order to install additional components or new version of packages e.g. PostgreSQL 10, it is required to:
 
 * Modify the files in [omero-install](https://github.com/ome/omero-install)
-* Create a new image of [devslave-c7-docker](https://github.com/openmicroscopy/devslave-c7-docker) using the updated omero-install files
+* Create a new image of [devslave-c7-docker](https://github.com/ome/devslave-c7-docker) using the updated omero-install files
 * Push the new image to [Docker Hub](https://hub.docker.com/). You will need to your own account
 * Modify each Dockerfile of this repository to use the new image
 

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -77,7 +77,7 @@ If you need to use non-released version of the scripts you will need to:
 ## Configure Push jobs
 
 Both BioFormats-push and OMERO-push can be modified to only merge the desired PR
-Below is an example on how to only include PRs opened against [openmicroscopy/openmicroscopy](https://github.com/openmicroscopy/openmicroscopy) with ``--training`` in their description
+Below is an example on how to only include PRs opened against [ome/openmicroscopy](https://github.com/ome/openmicroscopy) with ``--training`` in their description
 
  * Click on ``OMERO-push > Configure``
  * Go to ``MERGE_COMMAND`` and enter

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -7,7 +7,7 @@ RUN apk-install git && \
     mkdir /src
 
 RUN time git clone --bare --depth=1 -b v$TAG https://github.com/ome/scripts/ /src/scripts.git
-RUN time git clone --bare --depth=1 -b v$TAG https://github.com/openmicroscopy/openmicroscopy /src/omero.git
-RUN time git clone --bare --depth=1 -b v$TAG https://github.com/openmicroscopy/bioformats /src/bio-formats.git
+RUN time git clone --bare --depth=1 -b v$TAG https://github.com/ome/openmicroscopy /src/omero.git
+RUN time git clone --bare --depth=1 -b v$TAG https://github.com/ome/bioformats /src/bio-formats.git
 
 WORKDIR /src

--- a/home/config.xml
+++ b/home/config.xml
@@ -47,7 +47,7 @@
     <hudson.model.AllView>
       <owner class="hudson" reference="../../.."/>
       <name>all</name>
-      <description>See Job workflow https://github.com/openmicroscopy/devspace#job-workflow for more information</description>
+      <description>See Job workflow https://github.com/ome/devspace#job-workflow for more information</description>
       <filterExecutors>false</filterExecutors>
       <filterQueue>false</filterQueue>
       <properties class="hudson.model.View$PropertyList"/>

--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -38,7 +38,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>https://github.com/openmicroscopy/ome-documentation</url>
+        <url>https://github.com/ome/ome-documentation</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/home/jobs/OMERO-push/config.xml
+++ b/home/jobs/OMERO-push/config.xml
@@ -30,7 +30,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>https://github.com/openmicroscopy/openmicroscopy.git</url>
+        <url>https://github.com/ome/openmicroscopy.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/home/jobs/OMERO-test-integration/config.xml
+++ b/home/jobs/OMERO-test-integration/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description>For more info, see the &lt;a href=&quot;https://github.com/openmicroscopy/devspace#job-workflow&quot;/&gt;Job workflow&lt;/a&gt;.</description>
+  <description>For more info, see the &lt;a href=&quot;https://github.com/ome/devspace#job-workflow&quot;/&gt;Job workflow&lt;/a&gt;.</description>
   <keepDependencies>false</keepDependencies>
   <properties/>
   <scm class="hudson.scm.NullSCM"/>


### PR DESCRIPTION
This PR updates the link to the repo 
The repo name was changed a while back. redirect is in place but this is mainly to have repo up-to-date