### PR TITLE
git checkout: clone more recent tag

### DIFF
--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -9,7 +9,7 @@ RUN apk-install git && \
     mkdir /src
 
 RUN time git clone --bare --depth=1 -b v$TAGSCRIPTS https://github.com/ome/scripts/ /src/scripts.git
-RUN time git clone --bare --depth=1 -b vTAGSERVER https://github.com/ome/openmicroscopy /src/omero.git
-RUN time git clone --bare --depth=1 -b vTAGBF https://github.com/ome/bioformats /src/bio-formats.git
+RUN time git clone --bare --depth=1 -b v$TAGSERVER https://github.com/ome/openmicroscopy /src/omero.git
+RUN time git clone --bare --depth=1 -b v$TAGBF https://github.com/ome/bioformats /src/bio-formats.git
 
 WORKDIR /src

--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -1,13 +1,15 @@
 FROM mini/base
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-ENV TAG 5.1.4
+ENV TAGSERVER 5.6.5
+ENV TAGSCRIPTS 5.7.1
+ENV TAGBF 6.11.1
 
 RUN apk-install git && \
     mkdir /src
 
-RUN time git clone --bare --depth=1 -b v$TAG https://github.com/ome/scripts/ /src/scripts.git
-RUN time git clone --bare --depth=1 -b v$TAG https://github.com/ome/openmicroscopy /src/omero.git
-RUN time git clone --bare --depth=1 -b v$TAG https://github.com/ome/bioformats /src/bio-formats.git
+RUN time git clone --bare --depth=1 -b v$TAGSCRIPTS https://github.com/ome/scripts/ /src/scripts.git
+RUN time git clone --bare --depth=1 -b vTAGSERVER https://github.com/ome/openmicroscopy /src/omero.git
+RUN time git clone --bare --depth=1 -b vTAGBF https://github.com/ome/bioformats /src/bio-formats.git
 
 WORKDIR /src


### PR DESCRIPTION
Usage of one tag does not reflect the evolution of the tools.
* This PR uses 3 versions, one per repo, and uses latest versions for each repo.
