### PR TITLE
Jenkins LTS Java 11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
         environment:
             - SLAVE_NAME=testintegration
             - SLAVE_EXECUTORS=2
-            - SLAVE_PARAMS=-labels centos7 -labels ice36 -labels java18 -disableClientsUniqueId
+            - SLAVE_PARAMS=-labels centos7 -labels ice36 -labels java11 -disableClientsUniqueId
             - JENKINS_MASTER=${JENKINS_BASE}${JENKINS_PREFIX}
             - WEB_PREFIX
             - REPO_CONFIG
@@ -60,7 +60,7 @@ services:
         environment:
             - SLAVE_NAME=omero
             - SLAVE_EXECUTORS=2
-            - SLAVE_PARAMS=-labels centos7 -labels ice36 -labels java18 -disableClientsUniqueId
+            - SLAVE_PARAMS=-labels centos7 -labels ice36 -labels java11 -disableClientsUniqueId
             - JENKINS_MASTER=${JENKINS_BASE}${JENKINS_PREFIX}
             - WEBHOST=http://nginx${WEB_PREFIX}
         ports:
@@ -79,7 +79,7 @@ services:
         environment:
             - SLAVE_NAME=web
             - SLAVE_EXECUTORS=2
-            - SLAVE_PARAMS= -labels centos7 -labels ice36 -labels java18 -disableClientsUniqueId
+            - SLAVE_PARAMS= -labels centos7 -labels ice36 -labels java11 -disableClientsUniqueId
             - JENKINS_MASTER=${JENKINS_BASE}${JENKINS_PREFIX}
             - WEB_PREFIX
 
@@ -96,7 +96,7 @@ services:
             - ./nginx/sslcert:/etc/nginx/ssl
         environment:
             - SLAVE_NAME=nginx
-            - SLAVE_PARAMS=-labels centos7 -labels java18 -disableClientsUniqueId
+            - SLAVE_PARAMS=-labels centos7 -labels java11 -disableClientsUniqueId
             - JENKINS_MASTER=${JENKINS_BASE}${JENKINS_PREFIX}
         ports:
             - "${NGINX_PORT}80"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,12 @@ FROM openmicroscopy/devslave-c7:0.7.2
 
 MAINTAINER OME
 
+# manually install java11
+RUN yum -y install java-11-openjdk-devel
+# Switch Java version
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
+
 RUN yum -y install -y yum-utils \
   device-mapper-persistent-data \
   lvm2

--- a/home/config.xml
+++ b/home/config.xml
@@ -22,22 +22,6 @@
   <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
   <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
   <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
-  <jdks>
-    <jdk>
-      <name>JDK8</name>
-      <home></home>
-      <properties>
-        <hudson.tools.InstallSourceProperty>
-          <installers>
-            <hudson.tools.JDKInstaller plugin="jdk-tool@1.5">
-              <id>jdk-8u221-oth-JPR</id>
-              <acceptLicense>true</acceptLicense>
-            </hudson.tools.JDKInstaller>
-          </installers>
-        </hudson.tools.InstallSourceProperty>
-      </properties>
-    </jdk>
-  </jdks>
   <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
   <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
   <clouds/>

--- a/home/jobs/BIOFORMATS-build/config.xml
+++ b/home/jobs/BIOFORMATS-build/config.xml
@@ -59,12 +59,6 @@
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <axes>
-    <hudson.matrix.JDKAxis>
-      <name>jdk</name>
-      <values>
-        <string>JDK8</string>
-      </values>
-    </hudson.matrix.JDKAxis>
     <hudson.matrix.LabelAxis>
       <name>label</name>
       <values>

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.319.2-lts-jdk11
+FROM jenkins/jenkins:2.375.1-lts
 MAINTAINER OME
 
 # Temp fix robot test results

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -6,7 +6,9 @@ ENV JAVA_OPTS "-Dhudson.model.DirectoryBrowserSupport.CSP=" -Djenkins.install.ru
 
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+USER jenkins
+RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
+#RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 
 USER root
 RUN chown -R jenkins:jenkins /var/jenkins_home

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,6 +2,12 @@ FROM openmicroscopy/devslave-c7:0.7.1
 
 MAINTAINER OME
 
+# manually install java11
+RUN yum -y install java-11-openjdk
+# Switch Java version
+ENV JAVA_HOME /usr/lib/jvm/jre-11-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
+
 RUN yum -y localinstall http://nginx.org/packages/rhel/7/noarch/RPMS/nginx-release-rhel-7-0.el7.ngx.noarch.rpm \
     && yum clean all
 RUN yum -y install nginx --disablerepo=epel \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/devslave-c7:0.7.2
 
 MAINTAINER OME
 
-ARG JAVAVER=openjdk1.8
+ARG JAVAVER=openjdk11-devel
 ARG ICEVER=ice36
 ARG BRANCH=yourbranch
 ARG NAME=yourname
@@ -53,6 +53,11 @@ RUN JAVAVER=$JAVAVER ICEVER=$ICEVER PGVER=nopg bash install_centos7.sh
 # install postgres tools
 RUN yum -y install postgresql10 \
     && yum clean all
+
+# Switch Java version
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
+
 
 EXPOSE 4064
 EXPOSE 4063

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -7,6 +7,7 @@ ARG ICEVER=ice36-devel
 ARG BRANCH=yourbranch
 ARG NAME=yourname
 
+ARG GRADLEVER=6.9.3
 
 # skip some omero-install
 RUN echo 'export container=docker' > /etc/profile.d/docker.sh
@@ -62,10 +63,10 @@ RUN yum -y install postgresql10-server postgresql10 \
 
 # gradle
 RUN cd /opt && \
-    curl -fSLO https://services.gradle.org/distributions/gradle-5.2.1-bin.zip && \
-    unzip gradle-5.2.1-bin.zip && \
-    rm gradle-5.2.1-bin.zip && \
-    ln -s /opt/gradle-5.2.1/bin/gradle /usr/local/bin/gradle
+    curl -fSLO https://services.gradle.org/distributions/gradle-$GRADLEVER-bin.zip && \
+    unzip gradle-$GRADLEVER-bin.zip && \
+    rm gradle-$GRADLEVER-bin.zip && \
+    ln -s /opt/gradle-$GRADLEVER/bin/gradle /usr/local/bin/gradle
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 ENV PATH=$JAVA_HOME/bin:$PATH

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/devslave-c7:0.7.2
 
 MAINTAINER OME
 
-ARG JAVAVER=openjdk1.8
+ARG JAVAVER=openjdk11-devel
 ARG ICEVER=ice36-devel
 ARG BRANCH=yourbranch
 ARG NAME=yourname
@@ -66,8 +66,9 @@ RUN cd /opt && \
     unzip gradle-5.2.1-bin.zip && \
     rm gradle-5.2.1-bin.zip && \
     ln -s /opt/gradle-5.2.1/bin/gradle /usr/local/bin/gradle
-# Needed for Gradle
-ENV JAVA_HOME /usr/lib/jvm/jre-1.8.0-openjdk
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 EXPOSE 14064
 EXPOSE 14063

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,7 +2,6 @@ FROM openmicroscopy/devslave-c7:0.7.2
 
 MAINTAINER OME
 
-ARG JAVAVER=openjdk1.8
 ARG ICEVER=noice
 
 # make ICEVERSION environment variable to use in OMERO-web job
@@ -39,6 +38,12 @@ RUN yum install -y nodejs
 RUN npm install -g grunt
 
 RUN yum install -y python-redis && yum clean all
+
+# manually install java11
+RUN yum -y install java-11-openjdk
+# Switch Java version
+ENV JAVA_HOME /usr/lib/jvm/jre-11-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 EXPOSE 4080
 


### PR DESCRIPTION
Changes required to use a more recent version of jenkins running Java 11 
The latest is now at 2.386, this PR is using 2.375.1

This PR contains the set of changes to work with Java 11.
Version of the plugins also needs to be updated.

