### PR TITLE
Pg 13

### DIFF
--- a/.env
+++ b/.env
@@ -24,7 +24,7 @@ REPO_CURATED=/tmp/curated
 REPO_CONFIG=/tmp/config
 
 # Variables for controlling external dependencies versions
-POSTGRES_VERSION=10
+POSTGRES_VERSION=13
 NGINX_VERSION=1.15
 
 # Other variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
             - ./pgdata:/var/lib/postgresql/data
         ports:
             - "${POSTGRES_PORT}5432"
+        environment:
+            - POSTGRES_HOST_AUTH_METHOD=trust
 
     testintegration:
         build:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -51,7 +51,7 @@ WORKDIR /tmp/omero-install/linux
 RUN JAVAVER=$JAVAVER ICEVER=$ICEVER PGVER=nopg bash install_centos7.sh
 
 # install postgres tools
-RUN yum -y install postgresql10 \
+RUN yum -y install postgresql13 \
     && yum clean all
 
 EXPOSE 4064

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -fSLO http://downloads.sourceforge.net/project/findbugs/findbugs/$FINDB
 RUN yum -y install maven ant && yum clean all
 
 # install postgres tools
-RUN yum -y install postgresql10-server postgresql10 \
+RUN yum -y install postgresql13-server postgresql13 \
     && yum clean all
 
 # gradle


### PR DESCRIPTION
This PR upgrade postgres to version 13. A change in docker-compose is required to start the pg container since password needs to be provided.

The following migration workflow has been tested on new ci:

* Do a DB dump i.e. ``sudo docker exec -t PG_CONTAINER_ID pg_dumpall -c -U postgres > /tmp/dump_`date +%d-%m-%Y"_"%H_%M_%S`.sql``
* Delete ``pgdata`` directory
* run ``docker-compose -f docker-compose up``
* Check that ``Postgres:13`` container is up by running ``docker ps``
* Copy the DB dump file to the ``Postgres:13`` container i.e. ``docker cp dump_12-01-2023_11_47_22.sql PG_13_CONTAINER_ID:/tmp``
* Connect to the container's bash terminal ``docker exec -it PG_13_CONTAINER_ID bash``
* Import the DB: ``psql -U postgres -d postgres  < /tmp/dump_xxx.sql``
* Check that the ``OMERO-server`` and ``OMERO-test-integration`` have been created ``psql -U postgres -l``