### PR TITLE
cap dependency to fix bf-doc generation

### DIFF
--- a/home/jobs/BIOFORMATS-build/config.xml
+++ b/home/jobs/BIOFORMATS-build/config.xml
@@ -72,7 +72,6 @@
 source $WORKSPACE/venv/bin/activate
 
 cd bio-formats-build
-pip install &quot;urllib3<2&quot;
 pip install -r bio-formats-documentation/requirements.txt
 pip install -r ome-model/requirements.txt
 mvn deploy -DskipTests -DaltDeploymentRepository=ome.staging::default::http://admin:admin123@nexus:8081/nexus/repository/maven-internal/</command>

--- a/home/jobs/BIOFORMATS-build/config.xml
+++ b/home/jobs/BIOFORMATS-build/config.xml
@@ -72,6 +72,7 @@
 source $WORKSPACE/venv/bin/activate
 
 cd bio-formats-build
+pip install &quot;urllib3<2&quot;
 pip install -r ome-model/requirements.txt
 mvn deploy -DskipTests -DaltDeploymentRepository=ome.staging::default::http://admin:admin123@nexus:8081/nexus/repository/maven-internal/</command>
     </hudson.tasks.Shell>

--- a/home/jobs/BIOFORMATS-build/config.xml
+++ b/home/jobs/BIOFORMATS-build/config.xml
@@ -73,6 +73,7 @@ source $WORKSPACE/venv/bin/activate
 
 cd bio-formats-build
 pip install &quot;urllib3<2&quot;
+pip install -r bio-formats-documentation/requirements.txt
 pip install -r ome-model/requirements.txt
 mvn deploy -DskipTests -DaltDeploymentRepository=ome.staging::default::http://admin:admin123@nexus:8081/nexus/repository/maven-internal/</command>
     </hudson.tasks.Shell>


### PR DESCRIPTION
Problem noticed when deploying a new CI
Open ssl issue when building bf-doc 
cc @khaledk2 
