### PR TITLE
BIOFORMATS-image: include JDK 21 in the daily Java rotation

### DIFF
--- a/home/jobs/BIOFORMATS-image/config.xml
+++ b/home/jobs/BIOFORMATS-image/config.xml
@@ -32,12 +32,14 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>if (( $(date +%u) % 3 == 1 )); then
+      <command>if (( $(date +%u) % 4 == 1 )); then
     BASE_IMAGE=openjdk:8-slim-bullseye
-elif (( $(date +%u) % 3 == 2 )); then
+elif (( $(date +%u) % 4 == 2 )); then
     BASE_IMAGE=openjdk:11-slim-bullseye
-else
+elif (( $(date +%u) % 4 == 3 )); then
     BASE_IMAGE=openjdk:17-slim-bullseye
+else
+    BASE_IMAGE=openjdk:21-slim-bullseye
 fi
 
 sudo docker pull $BASE_IMAGE


### PR DESCRIPTION
This commit includes the minimal CI changes allowing to test Bio-Formats periodically on JDK21 as it has been deployed on https://merge-ci.openmicroscopy.org/jenkins