### PR TITLE
Disable pyramid generation as this is recommended

### DIFF
--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -155,6 +155,7 @@ omero config set omero.db.poolsize 25
 omero config set omero.security.trustStore /etc/pki/ca-trust/extracted/java/cacerts
 omero config set omero.security.trustStorePassword changeit
 omero config set omero.mail.config true
+omero config set omero.server.nodedescriptors master:Blitz-0,Indexer-0,Processor-0,Storm,Tables-0
 # omero config set omero.mail.from your_address
 # omero config set omero.mail.host your_smtp_server_for_example
 omero certificates


### PR DESCRIPTION
Trying to disable pyramid gen on merge-ci as per training, demo servers.
This is a recommended setup (not to have pyramid gen enabled).
I have tested it by directly editing the Config of OMERO-server job in jenkins and it worked.
Now adding it to devspace.

cc @jburel @will-moore 