### PR TITLE
Upgrade build containers to Python 3.11

### DIFF
--- a/home/jobs/BIOFORMATS-build/config.xml
+++ b/home/jobs/BIOFORMATS-build/config.xml
@@ -73,7 +73,7 @@
   </axes>
   <builders>
     <hudson.tasks.Shell>
-      <command>python3 -mvenv venv
+      <command>python3.11 -mvenv venv
 source $WORKSPACE/venv/bin/activate
 
 cd bio-formats-build

--- a/home/jobs/BIOFORMATS-push/config.xml
+++ b/home/jobs/BIOFORMATS-push/config.xml
@@ -72,7 +72,7 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>python3 -mvenv venv
+      <command>python3.11 -mvenv venv
 source $WORKSPACE/venv/bin/activate
 pip install -U pip
 pip install -U scc

--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -79,6 +79,7 @@ python3.11 -m venv $OMERO_VEN
 
 $OMERO_VEN/bin/pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
 $OMERO_VEN/bin/pip install -U setuptools omero-py
+source $OMERO_VEN/bin/activate
 source docs/hudson/OMERO.sh
 </command>
     </hudson.tasks.Shell>

--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -73,7 +73,7 @@ cd src
 export OMERO_BRANCH=$MERGE_PUSH_BRANCH
         
 OMERO_VEN=$WORKSPACE/omero-virtualenv      
-
+rm -rf $OMERO_VEN
 source $HOME/settings.env
 python3.11 -m venv $OMERO_VEN
 

--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -78,7 +78,7 @@ source $HOME/settings.env
 python3.11 -m venv $OMERO_VEN
 
 $OMERO_VEN/bin/pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
-$OMERO_VEN/bin/pip install -U setuptools omero-py
+$OMERO_VEN/bin/pip install -U &apos;setuptools&#60;66&apos; omero-py
 source $OMERO_VEN/bin/activate
 source docs/hudson/OMERO.sh
 </command>

--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -75,9 +75,9 @@ export OMERO_BRANCH=$MERGE_PUSH_BRANCH
 OMERO_VEN=$WORKSPACE/omero-virtualenv      
 
 source $HOME/settings.env
-python3 -m venv $OMERO_VEN
+python3.11 -m venv $OMERO_VEN
 
-$OMERO_VEN/bin/pip install https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl
+$OMERO_VEN/bin/pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
 $OMERO_VEN/bin/pip install -U setuptools omero-py
 source docs/hudson/OMERO.sh
 </command>

--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -61,7 +61,7 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>python3 -mvenv venv
+      <command>python3.11 -mvenv venv
 source $WORKSPACE/venv/bin/activate
 pip install -U pip
 pip install -U scc

--- a/home/jobs/OMERO-push/config.xml
+++ b/home/jobs/OMERO-push/config.xml
@@ -85,7 +85,7 @@
       <doNotFingerprintArtifacts>false</doNotFingerprintArtifacts>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.tasks.Shell>
-      <command>python3 -mvenv venv
+      <command>python3.11 -mvenv venv
 source $WORKSPACE/venv/bin/activate
 pip install -U pip
 pip install -U scc

--- a/home/jobs/OMERO-robot/config.xml
+++ b/home/jobs/OMERO-robot/config.xml
@@ -55,11 +55,11 @@
     <hudson.tasks.Shell>
       <command>
         rm -rf $WORKSPACE/.venv3
-python -m venv $WORKSPACE/.venv3
+python3.11 -m venv $WORKSPACE/.venv3
 
 source $WORKSPACE/.venv3/bin/activate
-pip install https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl
-pip install -U pip future setuptools
+pip install -U pip setuptools
+pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
 pip install omero-py omero-web  # Latest in order to stop server.
 </command>
     </hudson.tasks.Shell>

--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -54,7 +54,7 @@ if [ -e $OMERO_DIST ]; then
 fi
 
 rm -rf $WORKSPACE/.venv3
-python3 -m venv $WORKSPACE/.venv3
+python3.11 -m venv $WORKSPACE/.venv3
 
 if [ "$PURGE_DATA" = "true" ]; then
     dropdb -h $OMERO_DB_HOST -U $OMERO_DB_USER $OMERO_DB_NAME || echo "First run or already exists"
@@ -123,8 +123,8 @@ mv $WORKSPACE/$DIST $OMERO_DIST
 
 source $WORKSPACE/.venv3/bin/activate
 
-pip install https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl
-pip install -U pip future
+pip install -U pip
+pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
 pip install markdown
 pip install reportlab # For figure
 pip install omego

--- a/home/jobs/OMERO-test-integration/config.xml
+++ b/home/jobs/OMERO-test-integration/config.xml
@@ -15,11 +15,11 @@
   <builders>
     <hudson.tasks.Shell>
       <command>rm -rf $WORKSPACE/.venv3
-python3 -m venv $WORKSPACE/.venv3
+python3.11 -m venv $WORKSPACE/.venv3
 
 source $WORKSPACE/.venv3/bin/activate
-pip install https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl
-pip install -U pip future setuptools
+pip install -U pip setuptools
+pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
 pip install markdown
 pip install mox3 pytest pytest-django pytest-xdist pytest-mock
 pip install tables

--- a/home/jobs/OMERO-training/config.xml
+++ b/home/jobs/OMERO-training/config.xml
@@ -15,11 +15,11 @@
   <builders>
     <hudson.tasks.Shell>
       <command>rm -rf $WORKSPACE/.venv3
-python3 -m venv $WORKSPACE/.venv3
+python3.11 -m venv $WORKSPACE/.venv3
 
 source $WORKSPACE/.venv3/bin/activate
-pip install https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl
-pip install -U pip future setuptools
+pip install -U pip setuptools
+pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
 pip install markdown
 # Avoid installing psutil for now
 # https://github.com/pytest-dev/pytest-xdist/issues/585

--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -26,11 +26,11 @@
   <builders>
     <hudson.tasks.Shell>
       <command>rm -rf $WORKSPACE/.venv3
-python3 -m venv $WORKSPACE/.venv3
+python3.11 -m venv $WORKSPACE/.venv3
 
 source $WORKSPACE/.venv3/bin/activate
-pip install https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl
-pip install -U pip future
+pip install -U pip
+pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
 pip install markdown
 pip install omero-py omero-web  # Latest in order to stop server. NB: Re-installed from python-superbuild below</command>
     </hudson.tasks.Shell>

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /tmp/omero-install/linux
 
 
 RUN dnf install -y python3.11 python3.11-pip
-RUN pip install build
+RUN pip3.11 install build
 
 # Ice dependencies
 RUN dnf install -y 'dnf-command(config-manager)' && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod +x  /home/settings.env
 WORKDIR /tmp/omero-install/linux
 
 
-RUN dnf install -y python3 python3-pip
+RUN dnf install -y python3.11 python3.11-pip
 RUN pip install build
 
 # Ice dependencies

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -14,7 +14,7 @@ RUN chmod +x /home/settings.env
 RUN dnf install -y make
 
 # Python job
-RUN dnf install -y python3-setuptools python3-pip
+RUN dnf install -y python3.11 python3.11-pip
 RUN pip install build
 
 # Ice dependencies

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf install -y make
 
 # Python job
 RUN dnf install -y python3.11 python3.11-pip
-RUN pip install build
+RUN pip3.11 install build
 
 # Ice dependencies
 RUN dnf install -y 'dnf-command(config-manager)' && \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,7 +20,7 @@ RUN chown omero:omero /tmp/run.sh
 RUN chmod a+x /tmp/run.sh
 
 RUN dnf install -y python3.11 openssl python3.11-pip
-RUN pip install build
+RUN pip3.11 install build
 
 RUN dnf clean all
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -19,7 +19,7 @@ ADD ./run.sh /tmp/run.sh
 RUN chown omero:omero /tmp/run.sh
 RUN chmod a+x /tmp/run.sh
 
-RUN dnf install -y python3 openssl python3-pip
+RUN dnf install -y python3.11 openssl python3.11-pip
 RUN pip install build
 
 RUN dnf clean all


### PR DESCRIPTION
There are two reasons motivating this upgrade:

1- Python 3.9 is coming to its end of life in [October 2025](https://endoflife.date/python). This is modernizing the CI infrastructure to run the build & integration tests on a Python version available from the Rocky Linux 9 packages and with a few years of support
2- Using Python 3.10+ is a prerequisite to install `numpy 2.x` in the OMERO server virtual environment and assess the impact of this major release - see https://github.com/ome/omero-py/pull/445