### PR TITLE
Add default restart policies and logging options to all containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,15 @@
-services:
+# Define the default settings using &defaults
+x-defaults: &defaults
+  restart: unless-stopped
+  logging:
+    options:
+      max-size: "100m"
+      max-file: "3"
 
+services:
     jenkins:
         build: jenkins
+        <<: *defaults
         networks:
             - omero-network
         user: ${USER_ID}
@@ -12,6 +20,7 @@ services:
 
     pg:
         image: postgres:${POSTGRES_VERSION}
+        <<: *defaults
         networks:
             - omero-network
         volumes:
@@ -25,6 +34,7 @@ services:
         build:
             context: ./slave
             dockerfile: Dockerfile
+        <<: *defaults
         networks:
             - omero-network
         volumes:
@@ -52,6 +62,8 @@ services:
         build:
             context: ./server
             dockerfile: Dockerfile
+
+        <<: *defaults
         networks:
             - omero-network
         volumes:
@@ -75,6 +87,7 @@ services:
         build:
             context: ./web
             dockerfile: Dockerfile
+        <<: *defaults
         networks:
             - omero-network
         volumes:
@@ -91,6 +104,7 @@ services:
         build:
             context: ./nginx
             dockerfile: Dockerfile
+        <<: *defaults
         networks:
             - omero-network
         volumes:
@@ -108,6 +122,7 @@ services:
 
     nginxjenkins:
         image: nginx:${NGINX_VERSION}
+        <<: *defaults
         networks:
             - omero-network
         volumes:
@@ -119,11 +134,13 @@ services:
 
     redis:
         image: redis
+        <<: *defaults
         networks:
             - omero-network
 
     seleniumhub:
         image: selenium/hub
+        <<: *defaults
         networks:
             - omero-network
         environment:
@@ -133,6 +150,7 @@ services:
 
     seleniumfirefox:
         image: selenium/node-firefox
+        <<: *defaults
         networks:
             - omero-network
         environment:
@@ -149,6 +167,7 @@ services:
 
     seleniumchrome:
         image: selenium/node-chrome
+        <<: *defaults
         networks:
             - omero-network
         environment:
@@ -165,6 +184,7 @@ services:
 
     docker:
         build: docker
+        <<: *defaults
         networks:
             - omero-network
         volumes:
@@ -180,6 +200,7 @@ services:
 
     nexus:
         image: sonatype/nexus3:3.59.0
+        <<: *defaults
         user: ${USER_ID}
         networks:
             - omero-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,6 @@ services:
         build:
             context: ./server
             dockerfile: Dockerfile
-
         <<: *defaults
         networks:
             - omero-network


### PR DESCRIPTION
@pwalczysko  has updated the `nginxjenkins` container to ensure it always restarts on the `idr3-slot2` server. 
I think the same should be applied to all containers to ensure that all containers automatically restart when the machine reboots or fails for any reason

This PR changes the `restart` policy to `unless-stopped` to all containers.

In addition, it sets logging options for each container:

-  The size of the log file to be 100  mb, so no single log file grows indefinitely.
-  Docker will keep up to three log files for each container

This configuration helps in maintaining the health and performance of  the containers by ensuring that logs do not consume too much disk space.