### PR TITLE
Remove Spring LDAP workaround to start the server on Java 17+

### DIFF
--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -179,7 +179,7 @@ omero config set omero.security.trustStore /etc/pki/ca-trust/extracted/java/cace
 omero config set omero.security.trustStorePassword changeit
 omero config set omero.mail.config true
 omero config set omero.server.nodedescriptors master:Blitz-0,Indexer-0,Processor-0,Storm,Tables-0
-omero config set omero.jvmcfg.append '--add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED'
+omero config set omero.jvmcfg.append '--add-opens java.base/java.lang=ALL-UNNAMED'
 
 # omero config set omero.mail.from your_address
 # omero config set omero.mail.host your_smtp_server_for_example

--- a/home/jobs/OMERO-test-integration/config.xml
+++ b/home/jobs/OMERO-test-integration/config.xml
@@ -119,7 +119,7 @@ omero certificates
 ## END LOAD CONFIG
 
 # Java config
-omero config set omero.jvmcfg.append '--add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED'
+omero config set omero.jvmcfg.append '--add-opens java.base/java.lang=ALL-UNNAMED'
 
 ## PURGE
 


### PR DESCRIPTION
See https://github.com/ome/openmicroscopy/issues/6383#issuecomment-4183979465 The Spring LDAP core dependency was upgrade on OMERO.server 5.6.16 so this configuration is now unnecessary to start OMERO.server on recent LTS versions of Java